### PR TITLE
Parse import statements using kde-master's qmlimport

### DIFF
--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -107,7 +107,7 @@ QMLEngine = function (element, options) {
         // Create and initialize objects
         var component = new QMLComponent({ object: tree, parent: null });
         doc = component.createObject(null);
-        component.finalizeImports();
+        component.finalizeImports(this.rootContext());
         this.$initializePropertyBindings();
 
         this.start();

--- a/src/qtcore/qml/elements/Component.js
+++ b/src/qtcore/qml/elements/Component.js
@@ -22,14 +22,10 @@ function QMLComponent(meta) {
 
     var jsImports = [];
 
-    var loadJsImport = (function(importDesc) {
-      jsImports.push(importDesc);
-    }).bind(this);
-
-    this.finalizeImports = (function() {
+    this.finalizeImports = (function($context) {
       for (var i = 0 ; i < jsImports.length ; ++i) {
         var importDesc = jsImports[i];
-        var src = importDesc.subject;
+        var src = importDesc[1];
         var js;
 
         if (typeof qmlEngine.basePath != 'undefined')
@@ -37,31 +33,22 @@ function QMLComponent(meta) {
         if (typeof qrc[src] != 'undefined')
           js = qrc[src];
         else
-          js = jsparse(getUrlContents(src));
-        var $context = qmlEngine.rootContext();
-        $context[importDesc.alias] = {};
-        importJavascriptInContext(js, $context[importDesc.alias]);
+          js = global.jsparse(getUrlContents(src));
+        if (importDesc[3] !== "") {
+          $context[importDesc[3]] = {};
+          importJavascriptInContext(js, $context[importDesc[3]]);
+        }
+        else
+          importJavascriptInContext(js, $context);
       }
     }).bind(this);
-
-    var loadQmlImport = (function(importDesc) {
-      var src = importDesc.subject;
-      var qml;
-
-      if (typeof qmlEngine.basePath != 'undefined')
-        src = qmlEngine.basePath + src;
-      qml = getUrlContents(src);
-      qmlEngine.loadQML(qml);
-    });
 
     if (meta.object.$imports instanceof Array)
     {
       var moduleImports = [];
       var loadImport    = (function(importDesc) {
-        if (/\.js$/.test(importDesc.subject))
-          loadJsImport(importDesc);
-        else if (/\.qml$/.test(importDesc.subject))
-          loadQmlImport(importDesc);
+        if (/\.js$/.test(importDesc[1]))
+          jsImports.push(importDesc);
         else
           moduleImports.push(importDesc);
       }).bind(this);
@@ -70,6 +57,8 @@ function QMLComponent(meta) {
         loadImport(meta.object.$imports[i]);
       }
       loadImports(this, moduleImports);
+      if (typeof this.$context != 'undefined' && this.$context != null)
+        this.finalizeImports(this.$context);
     }
 }
 

--- a/src/qtcore/qml/lib/jsparser.js
+++ b/src/qtcore/qml/lib/jsparser.js
@@ -7,7 +7,7 @@
     uglify_parse = parse;
 
   global.importJavascriptInContext = function (jsData, $context) {
-    with(qmlEngine.rootContext()) {
+    with($context) {
       eval(jsData.source);
       for (var i = 0 ; i < jsData.exports.length ; ++i) {
         var symbolName = jsData.exports[i];

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -102,13 +102,15 @@ global.perContextConstructors = {};
 global.loadImports = function (self, imports) {
   constructors = mergeObjects(modules.Main, null);
   for (var i = 0 ; i < imports.length ; ++i) {
-    var importDesc         = imports[i];
-    var moduleConstructors = collectConstructorsForModule(importDesc.subject, importDesc.version);
+    var moduleName = imports[i][1],
+        moduleVersion = imports[i][2],
+        moduleAlias = imports[i][3],
+        moduleConstructors = collectConstructorsForModule(moduleName, moduleVersion);
 
-    if (importDesc.alias != null)
-      constructors[importDesc.alias] = mergeObjects(constructors[importDesc.alias], moduleConstructors);
+    if (moduleAlias !== "")
+      constructors[moduleAlias] = mergeObjects(constructors[moduleAlias], moduleConstructors);
     else
-      constructors                   = mergeObjects(constructors,                   moduleConstructors);
+      constructors = mergeObjects(constructors, moduleConstructors);
   }
   perContextConstructors[self.objectId] = constructors;
 }


### PR DESCRIPTION
I patched the code from master so that it would load modules and javascript imports using the qmlimport parser form kde-master, instead of the one currently in master (which was written by myself a long time ago, and shouldn't be kept, as it is less concise and doesn't conform to the parsing logic used everywhere else).

I also removed the import of QML files (such as: import my.qml), since I couldn't get it to work right away, and didn't find anything in the QML documentation about these kind of imports.

The only missing thing from import is the recursive import of a directory containing qml files. Could be done for node.js users, though for web browsers, we can only do it using the qrc thingy (since we can't access the filesystem). We may want to open a low priority issue to add that feature in the future.