### PR TITLE
package.json improvements: explicitly list files, add repo field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.4",
   "description": "QML port to Javascript",
   "license": "BSD",
+  "repository": "qmlweb/qmlweb",
   "devDependencies": {
     "gulp": "^3.6.2",
     "gulp-concat": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,17 @@
     "test": "./node_modules/.bin/gulp test",
     "build": "./node_modules/.bin/gulp build",
     "watch": "./node_modules/.bin/gulp watch"
-  }
+  },
+  "files": [
+    "AUTHORS",
+    "LICENSE",
+    "README.md",
+    "misc/**/*.svg",
+    "misc/**/*.png",
+    "lib/**/*.js",
+    "src/**/*.js",
+    "src/**/*.qml",
+    "tests/**/*.js",
+    "tests/**/*.qml"
+  ]
 }


### PR DESCRIPTION
Explicitly listing files is one of two ways of overriding `.gitignore` if we put `lib/` there, another one would be to maintain an `.npmignore` that is equal to `.gitignore` minus the `lib/`, but that would be inconvenvient and would affect the `.gitignore` merges, perhaps.

This also ensures that no unexpected files are packaged (note that there are no directories listed, only glob patters with file extensions).

`tests` and `src` are packages purposely, I think that those should be always coupled with the built lib, also note that `src` could be used directly atm.

Including the `repository` field should give us a link to the repository, issues, and pull requests at the npm package page.
