### PR TITLE
gulpfile: rebuild ./lib only if needed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var order   = require('gulp-order');
 var uglify  = require('gulp-uglify');
 var concat  = require('gulp-concat');
 var rename  = require('gulp-rename');
+var changed = require('gulp-changed');
 var jasmine = require('gulp-jasmine-phantom');
 
 var qtcoreSources = [
@@ -37,12 +38,14 @@ gulp.task('qt', function() {
   return gulp.src(qtcoreSources)
              .pipe(order(qtcoreSources, { base: __dirname }))
              .pipe(concat('qt.js'))
+             .pipe(changed('./lib'))
              .pipe(gulp.dest('./lib'));
 });
 
 gulp.task('min-qt', ['qt'], function() {
   return gulp.src('./lib/qt.js')
              .pipe(rename('qt.min.js'))
+             .pipe(changed('./lib'))
              .pipe(uglify())
              .pipe(gulp.dest('./lib'));
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "qmlweb/qmlweb",
   "devDependencies": {
     "gulp": "^3.6.2",
+    "gulp-changed": "^1.3.0",
     "gulp-concat": "^2.1.7",
     "gulp-jasmine-phantom": "^3.0.0-rc1",
     "gulp-order": "^1.1.1",


### PR DESCRIPTION
This uses `gulp-changed` to achive that.

Will be userful for writing (and testing) tests, because atm it consumes an extra 4 seconds on my notebook on the minification stage.