### PR TITLE
gulpfile: Add sourcemaps.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,10 @@
-var gulp    = require('gulp');
-var order   = require('gulp-order');
-var uglify  = require('gulp-uglify');
-var concat  = require('gulp-concat');
-var rename  = require('gulp-rename');
+var gulp = require('gulp');
+var concat = require('gulp-concat');
+var rename = require('gulp-rename');
 var changed = require('gulp-changed');
+var order = require('gulp-order');
+var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 var jasmine = require('gulp-jasmine-phantom');
 
 var qtcoreSources = [
@@ -37,8 +38,10 @@ var tests = [
 gulp.task('qt', function() {
   return gulp.src(qtcoreSources)
              .pipe(order(qtcoreSources, { base: __dirname }))
+             .pipe(sourcemaps.init())
              .pipe(concat('qt.js'))
              .pipe(changed('./lib'))
+             .pipe(sourcemaps.write('./'))
              .pipe(gulp.dest('./lib'));
 });
 
@@ -46,7 +49,9 @@ gulp.task('min-qt', ['qt'], function() {
   return gulp.src('./lib/qt.js')
              .pipe(rename('qt.min.js'))
              .pipe(changed('./lib'))
+             .pipe(sourcemaps.init({ loadMaps: true }))
              .pipe(uglify())
+             .pipe(sourcemaps.write('./'))
              .pipe(gulp.dest('./lib'));
 });
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-jasmine-phantom": "^3.0.0-rc1",
     "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^0.2.1"
   },
   "scripts": {


### PR DESCRIPTION
These are needed for various reasons, including debugging and (hopefully) coverage analysis.