### PR TITLE
Use karma, add Coveralls integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib/
+coverage/
 tmp/
 build/
 *~

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join the chat at https://gitter.im/qmlweb/qmlweb](https://badges.gitter.im/qmlweb/qmlweb.svg)](https://gitter.im/qmlweb/qmlweb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/qmlweb/qmlweb.svg?branch=master)](https://travis-ci.org/qmlweb/qmlweb)
+[![Coverage Status](https://coveralls.io/repos/github/qmlweb/qmlweb/badge.svg?branch=master)](https://coveralls.io/github/qmlweb/qmlweb?branch=master)
+
 [![npm](https://img.shields.io/npm/v/qmlweb.svg)](https://www.npmjs.com/package/qmlweb)
 [![Bower](https://img.shields.io/bower/v/qmlweb.svg)](http://bower.io/search/?q=qmlweb)
 [![GitHub tag](https://img.shields.io/github/tag/qmlweb/qmlweb.svg)](https://github.com/qmlweb/qmlweb/releases)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,13 @@ gulp.task('build', ['qt', 'min-qt']);
 
 gulp.task('test', ['build'], function(done) {
   new karma.Server({
+    singleRun: true,
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
+});
+
+gulp.task('karma', ['build'], function(done) {
+  new karma.Server({
     configFile: __dirname + '/karma.conf.js'
   }, done).start();
 });
@@ -67,9 +74,6 @@ gulp.task('watch', ['build'], function() {
   gulp.watch(qtcoreSources, ['build']);
 });
 
-gulp.task('watch-tests', ['build', 'test'],function() {
-  gulp.watch(qtcoreSources, ['build', 'test']);
-  gulp.watch(tests, ['test']);
-});
+gulp.task('watch-tests', ['watch', 'karma']);
 
 gulp.task('default', ['watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var changed = require('gulp-changed');
 var order = require('gulp-order');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
-var jasmine = require('gulp-jasmine-phantom');
+var karma = require('karma');
 
 var qtcoreSources = [
   'src/helpers/encapsulate.begin.js',
@@ -57,12 +57,10 @@ gulp.task('min-qt', ['qt'], function() {
 
 gulp.task('build', ['qt', 'min-qt']);
 
-gulp.task('test', ['build'], function() {
-  return gulp.src(tests)
-             .pipe(jasmine({
-               integration: true,
-               vendor: ['./lib/qt.js']
-             }));
+gulp.task('test', ['build'], function(done) {
+  new karma.Server({
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
 });
 
 gulp.task('watch', ['build'], function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,9 @@ module.exports = function(config) {
     ],
     browsers: ['PhantomJS'],
     singleRun: true,
-    reporters: ['progress', 'coverage'],
+    reporters: process.env.COVERALLS_REPO_TOKEN ?
+                   ['progress', 'coverage', 'coveralls'] :
+                   ['progress', 'coverage'],
     coverageReporter: {
       type: 'lcov',
       dir: 'coverage/'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,20 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine'],
+    files: [
+      'lib/qt.js',
+      'tests/**/*.js'
+    ],
+    browsers: ['PhantomJS'],
+    singleRun: true,
+    reporters: ['progress', 'coverage'],
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage/'
+    },
+    preprocessors: {
+      'lib/qt.js': ['coverage']
+    }
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,6 @@ module.exports = function(config) {
       'tests/**/*.js'
     ],
     browsers: ['PhantomJS'],
-    singleRun: true,
     reporters: process.env.COVERALLS_REPO_TOKEN ?
                    ['progress', 'coverage', 'coveralls'] :
                    ['progress', 'coverage'],

--- a/package.json
+++ b/package.json
@@ -8,11 +8,16 @@
     "gulp": "^3.6.2",
     "gulp-changed": "^1.3.0",
     "gulp-concat": "^2.1.7",
-    "gulp-jasmine-phantom": "^3.0.0-rc1",
     "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^0.2.1"
+    "gulp-uglify": "^0.2.1",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.21",
+    "karma-coverage": "^0.5.3",
+    "karma-jasmine": "^0.3.7",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.4"
   },
   "scripts": {
     "test": "./node_modules/.bin/gulp test",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-coverage": "^0.5.3",
+    "karma-coveralls": "^1.1.2",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.4"


### PR DESCRIPTION
This gives us crude coverage analysis.
It's based on a single file atm (`lib/qt.js`), that has to be fixed later.
Another related problem is that it also analyzes the bundled `uglify-js` code.

There are several ways of fixing that, but that could be done in follow-up PRs.

This (sort of) fixes #40.