### PR TITLE
Language tests and context fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 lib/
+coverage/
 tmp/
 build/
 *~

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join the chat at https://gitter.im/qmlweb/qmlweb](https://badges.gitter.im/qmlweb/qmlweb.svg)](https://gitter.im/qmlweb/qmlweb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/qmlweb/qmlweb.svg?branch=master)](https://travis-ci.org/qmlweb/qmlweb)
+[![Coverage Status](https://coveralls.io/repos/github/qmlweb/qmlweb/badge.svg?branch=master)](https://coveralls.io/github/qmlweb/qmlweb?branch=master)
+
 [![npm](https://img.shields.io/npm/v/qmlweb.svg)](https://www.npmjs.com/package/qmlweb)
 [![Bower](https://img.shields.io/bower/v/qmlweb.svg)](http://bower.io/search/?q=qmlweb)
 [![GitHub tag](https://img.shields.io/github/tag/qmlweb/qmlweb.svg)](https://github.com/qmlweb/qmlweb/releases)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+
 var gulp = require('gulp');
 var concat = require('gulp-concat');
 var rename = require('gulp-rename');
@@ -67,6 +68,11 @@ gulp.task('test', ['build'], function(done) {
 gulp.task('karma', ['build'], function(done) {
   new karma.Server({
     configFile: __dirname + '/karma.conf.js'
+  }, done).start();
+});
+gulp.task('karma-debug', ['build'], function(done) {
+  new karma.Server({
+    configFile: __dirname + '/karma.debug.conf.js'
   }, done).start();
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,13 @@ gulp.task('build', ['qt', 'min-qt']);
 
 gulp.task('test', ['build'], function(done) {
   new karma.Server({
+    singleRun: true,
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
+});
+
+gulp.task('karma', ['build'], function(done) {
+  new karma.Server({
     configFile: __dirname + '/karma.conf.js'
   }, done).start();
 });
@@ -67,9 +74,6 @@ gulp.task('watch', ['build'], function() {
   gulp.watch(qtcoreSources, ['build']);
 });
 
-gulp.task('watch-tests', ['build', 'test'],function() {
-  gulp.watch(qtcoreSources, ['build', 'test']);
-  gulp.watch(tests, ['test']);
-});
+gulp.task('watch-tests', ['watch', 'karma']);
 
 gulp.task('default', ['watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var changed = require('gulp-changed');
 var order = require('gulp-order');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
-var jasmine = require('gulp-jasmine-phantom');
+var karma = require('karma');
 
 var qtcoreSources = [
   'src/helpers/encapsulate.begin.js',
@@ -57,12 +57,10 @@ gulp.task('min-qt', ['qt'], function() {
 
 gulp.task('build', ['qt', 'min-qt']);
 
-gulp.task('test', ['build'], function() {
-  return gulp.src(tests)
-             .pipe(jasmine({
-               integration: true,
-               vendor: ['./lib/qt.js']
-             }));
+gulp.task('test', ['build'], function(done) {
+  new karma.Server({
+    configFile: __dirname + '/karma.conf.js'
+  }, done).start();
 });
 
 gulp.task('watch', ['build'], function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,9 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
     files: [
       'lib/qt.js',
-      'tests/**/*.js'
+      'tests/common.js',
+      'tests/*/**/*.js',
+      { pattern: 'tests/*/**/*.qml', included: false }
     ],
     browsers: ['PhantomJS'],
     reporters: process.env.COVERALLS_REPO_TOKEN ?

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,9 @@ module.exports = function(config) {
     ],
     browsers: ['PhantomJS'],
     singleRun: true,
-    reporters: ['progress', 'coverage'],
+    reporters: process.env.COVERALLS_REPO_TOKEN ?
+                   ['progress', 'coverage', 'coveralls'] :
+                   ['progress', 'coverage'],
     coverageReporter: {
       type: 'lcov',
       dir: 'coverage/'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,20 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine'],
+    files: [
+      'lib/qt.js',
+      'tests/**/*.js'
+    ],
+    browsers: ['PhantomJS'],
+    singleRun: true,
+    reporters: ['progress', 'coverage'],
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage/'
+    },
+    preprocessors: {
+      'lib/qt.js': ['coverage']
+    }
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function(config) {
     },
     preprocessors: {
       'lib/qt.js': ['coverage']
-    }
+    },
+
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,6 @@ module.exports = function(config) {
       'tests/**/*.js'
     ],
     browsers: ['PhantomJS'],
-    singleRun: true,
     reporters: process.env.COVERALLS_REPO_TOKEN ?
                    ['progress', 'coverage', 'coveralls'] :
                    ['progress', 'coverage'],

--- a/karma.debug.conf.js
+++ b/karma.debug.conf.js
@@ -1,0 +1,8 @@
+
+module.exports = function(config) {
+  require("./karma.conf.js")(config)
+  config.browsers.push("Chrome")
+  config.set({
+    debug: true,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -8,11 +8,16 @@
     "gulp": "^3.6.2",
     "gulp-changed": "^1.3.0",
     "gulp-concat": "^2.1.7",
-    "gulp-jasmine-phantom": "^3.0.0-rc1",
     "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^0.2.1"
+    "gulp-uglify": "^0.2.1",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.21",
+    "karma-coverage": "^0.5.3",
+    "karma-jasmine": "^0.3.7",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.4"
   },
   "scripts": {
     "test": "./node_modules/.bin/gulp test",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-coverage": "^0.5.3",
+    "karma-coveralls": "^1.1.2",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.4"

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -121,9 +121,6 @@ function construct(meta) {
     } else if (component = Qt.createComponent(meta.object.$class + ".qml", meta.context)) {
         var item = component.createObject(meta.parent);
 
-        // Alter objects context to the outer context
-        item.$context = meta.$context;
-
         if (typeof item.dom != 'undefined')
           item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");
         var dProp; // Handle default properties
@@ -137,7 +134,7 @@ function construct(meta) {
         meta.context[meta.object.id] = item;
 
     // Apply properties (Bindings won't get evaluated, yet)
-    applyProperties(meta.object, item, item, meta.context);
+    applyProperties(meta.object, item, item, item.$context);
 
     return item;
 }

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -3,7 +3,7 @@
  */
 describe('properties', function() {
     var loader = prefixedQmlLoader('QMLEngine/qml/');
-    it('assigned values', function() {
+    it('can store values', function() {
         var qml = loader('BasicProperties');
         var div = qml.rootElement
         expect(qml).not.toBe(undefined)
@@ -11,9 +11,10 @@ describe('properties', function() {
         expect(qml.rootObject.intProperty).toBe(10)
         expect(qml.rootObject.doubleProperty).toBe(0.5)
         expect(qml.rootObject.stringProperty).toBe("hello")
+        expect(qml.rootObject.itemProperty.x).not.toBe(undefined)
     });
 
-    it('property binding', function() {
+    it('can maintain property bindings', function() {
         var qml = loader('BoundProperties');
         var obj = qml.rootObject
 
@@ -37,5 +38,13 @@ describe('properties', function() {
         var childB = contextVariable(parentItem, "childB")
         expect(childB).not.toBe(undefined)
     });
+
+    it('can be aliased', function(){
+        var qml = loader('RootItem');
+        var obj = qml.rootObject
+        expect(obj.childX).toBe(125)
+
+    });
+
 
 });

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -1,0 +1,49 @@
+/**
+ * Created by henrik on 20.02.16.
+ */
+describe('properties', function() {
+    var loader = prefixedQmlLoader('QMLEngine/qml/');
+    it('assigned values', function() {
+        var qml = loader('BasicProperties');
+        var div = qml.rootElement
+        expect(qml).not.toBe(undefined)
+        expect(qml.rootObject).not.toBe(null)
+        expect(qml.rootObject.intProperty).toBe(10)
+        expect(qml.rootObject.doubleProperty).toBe(0.5)
+        expect(qml.rootObject.stringProperty).toBe("hello")
+    });
+
+    it('property binding', function() {
+        var qml = loader('BoundProperties');
+        var obj = qml.rootObject
+
+        expect(obj.intB).toBe(20)
+        expect(obj.textB).toBe("hello world")
+        obj.intA = 5
+        expect(obj.intB).toBe(10)
+        obj.textA = "goodbye"
+        expect(obj.textB).toBe("goodbye world")
+
+    });
+
+    //it('reference by ids', function() {
+    //    var qml = loader('BoundProperties');
+    //    var obj = qml.rootObject
+    //    expect(obj.parentItem).not.toBe(undefined)
+    //
+    //});
+    //
+    //it('scoping', function() {
+    //    var qml = loader('RootItem');
+    //    var obj = qml.rootObject.parent
+    //
+    //    expect(obj.intB).toBe(20)
+    //    expect(obj.textB).toBe("hello world")
+    //    obj.intA = 5
+    //    expect(obj.intB).toBe(10)
+    //    obj.textA = "goodbye"
+    //    expect(obj.textB).toBe("goodbye world")
+    //
+    //});
+
+});

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -12,6 +12,7 @@ describe('properties', function() {
         expect(qml.rootObject.doubleProperty).toBe(0.5)
         expect(qml.rootObject.stringProperty).toBe("hello")
         expect(qml.rootObject.itemProperty.x).not.toBe(undefined)
+        expect(qml.rootObject.arrayProperty).toEqual([1,2,"bar"])
     });
 
     it('can maintain property bindings', function() {
@@ -39,7 +40,7 @@ describe('properties', function() {
         expect(childB).not.toBe(undefined)
     });
 
-    it('can be aliased', function(){
+    it.cannot('be aliased', function(){
         var qml = loader('RootItem');
         var obj = qml.rootObject
         expect(obj.childX).toBe(125)

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -26,24 +26,16 @@ describe('properties', function() {
 
     });
 
-    //it('reference by ids', function() {
-    //    var qml = loader('BoundProperties');
-    //    var obj = qml.rootObject
-    //    expect(obj.parentItem).not.toBe(undefined)
-    //
-    //});
-    //
-    //it('scoping', function() {
-    //    var qml = loader('RootItem');
-    //    var obj = qml.rootObject.parent
-    //
-    //    expect(obj.intB).toBe(20)
-    //    expect(obj.textB).toBe("hello world")
-    //    obj.intA = 5
-    //    expect(obj.intB).toBe(10)
-    //    obj.textA = "goodbye"
-    //    expect(obj.textB).toBe("goodbye world")
-    //
-    //});
+    it('reference by ids', function() {
+        var qml = loader('RootItem');
+        var obj = qml.rootObject
+        var parentItem = contextVariable(obj, "parentItem")
+        expect(parentItem).not.toBe(undefined)
+        expect(parentItem.$context).not.toBe(undefined)
+        var childA = contextVariable(parentItem, "childA")
+        expect(childA).not.toBe(undefined)
+        var childB = contextVariable(parentItem, "childB")
+        expect(childB).not.toBe(undefined)
+    });
 
 });

--- a/tests/QMLEngine/qml/AliasProperties
+++ b/tests/QMLEngine/qml/AliasProperties
@@ -1,0 +1,8 @@
+Item {
+    property alias childX: child.x
+    Item{
+        id: child
+        x: 125
+    }
+
+}

--- a/tests/QMLEngine/qml/BasicProperties.qml
+++ b/tests/QMLEngine/qml/BasicProperties.qml
@@ -1,0 +1,5 @@
+Item{
+    property int intProperty: 10
+    property double doubleProperty: 0.5
+    property string stringProperty: "hello"
+}

--- a/tests/QMLEngine/qml/BasicProperties.qml
+++ b/tests/QMLEngine/qml/BasicProperties.qml
@@ -3,5 +3,5 @@ Item{
     property double doubleProperty: 0.5
     property string stringProperty: "hello"
     property Item itemProperty: Item{ }
-
+    property var arrayProperty: [1,2,"bar"]
 }

--- a/tests/QMLEngine/qml/BasicProperties.qml
+++ b/tests/QMLEngine/qml/BasicProperties.qml
@@ -2,4 +2,6 @@ Item{
     property int intProperty: 10
     property double doubleProperty: 0.5
     property string stringProperty: "hello"
+    property Item itemProperty: Item{ }
+
 }

--- a/tests/QMLEngine/qml/BoundProperties.qml
+++ b/tests/QMLEngine/qml/BoundProperties.qml
@@ -1,0 +1,6 @@
+Item{
+    property int intA: 10
+    property int intB: intA * 2
+    property string textA: "hello"
+    property string textB: textA + " world"
+}

--- a/tests/QMLEngine/qml/ChildItem.qml
+++ b/tests/QMLEngine/qml/ChildItem.qml
@@ -1,0 +1,4 @@
+Item{
+    property int value: 2
+    property int totalValue: (parentItem.value + rootItem.value) * value
+}

--- a/tests/QMLEngine/qml/ComponentProperty.qml
+++ b/tests/QMLEngine/qml/ComponentProperty.qml
@@ -1,5 +1,3 @@
 Item{
-    property Item item: Item{
 
-    }
 }

--- a/tests/QMLEngine/qml/ComponentProperty.qml
+++ b/tests/QMLEngine/qml/ComponentProperty.qml
@@ -1,0 +1,5 @@
+Item{
+    property Item item: Item{
+
+    }
+}

--- a/tests/QMLEngine/qml/ParentItem.qml
+++ b/tests/QMLEngine/qml/ParentItem.qml
@@ -1,0 +1,14 @@
+Item{
+    id: parentItem
+    property int value: 100
+    property int sum: childA.totalValue + childB.totalValue
+
+    ChildItem{
+        id: childA
+        value: 2
+    }
+    ChildItem{
+        id: childB
+        value: 4
+    }
+}

--- a/tests/QMLEngine/qml/RootItem.qml
+++ b/tests/QMLEngine/qml/RootItem.qml
@@ -1,0 +1,7 @@
+Item{
+    id: rootItem
+    property int rootValue: 1000
+    ParentItem{
+        id: parentItem
+    }
+}

--- a/tests/QtQuick/Item.js
+++ b/tests/QtQuick/Item.js
@@ -1,0 +1,17 @@
+describe('QtQuick.Item', function() {
+  var loader = prefixedQmlLoader('QtQuick/qml/Item');
+  it('Empty', function() {
+    var div = loader('Empty');
+    expect(div.innerHTML).toBe('');
+    div.remove();
+  });
+  it('Size', function() {
+    var div = loader('Size');
+    expect(div.innerHTML).toBe('');
+    expect(div.offsetWidth).toBe(200);
+    expect(div.offsetHeight).toBe(100);
+    expect(div.clientWidth).toBe(200);
+    expect(div.clientHeight).toBe(100);
+    div.remove();
+  });
+});

--- a/tests/QtQuick/Item.js
+++ b/tests/QtQuick/Item.js
@@ -1,13 +1,13 @@
 describe('QtQuick.Item', function() {
   var loader = prefixedQmlLoader('QtQuick/qml/Item');
   it('Empty', function() {
-    var div = loader('Empty');
+    var div = loader('Empty').rootElement;
     expect(div.innerHTML).toBe('');
     expect(div.style.backgroundColor).toBe('');
     div.remove();
   });
   it('Size', function() {
-    var div = loader('Size');
+    var div = loader('Size').rootElement;
     expect(div.offsetWidth).toBe(200);
     expect(div.offsetHeight).toBe(100);
     expect(div.clientWidth).toBe(200);

--- a/tests/QtQuick/Item.js
+++ b/tests/QtQuick/Item.js
@@ -3,11 +3,11 @@ describe('QtQuick.Item', function() {
   it('Empty', function() {
     var div = loader('Empty');
     expect(div.innerHTML).toBe('');
+    expect(div.style.backgroundColor).toBe('');
     div.remove();
   });
   it('Size', function() {
     var div = loader('Size');
-    expect(div.innerHTML).toBe('');
     expect(div.offsetWidth).toBe(200);
     expect(div.offsetHeight).toBe(100);
     expect(div.clientWidth).toBe(200);

--- a/tests/QtQuick/Rectangle.js
+++ b/tests/QtQuick/Rectangle.js
@@ -1,0 +1,23 @@
+describe('QtQuick.Rectangle', function() {
+  var loader = prefixedQmlLoader('QtQuick/qml/Rectangle');
+  it('White', function() {
+    var div = loader('White');
+    expect(div.innerHTML).toBe('');
+    expect(div.style.backgroundColor).toBe('white');
+    expect(div.offsetWidth).toBe(200);
+    expect(div.offsetHeight).toBe(100);
+    expect(div.clientWidth).toBe(200);
+    expect(div.clientHeight).toBe(100);
+    div.remove();
+  });
+  it('Color', function() {
+    var div = loader('Color');
+    expect(div.style.backgroundColor).toBe('red');
+    div.remove();
+  });
+  it('Transparent', function() {
+    var div = loader('Transparent');
+    expect(div.style.backgroundColor).toBe('transparent');
+    div.remove();
+  });
+});

--- a/tests/QtQuick/Rectangle.js
+++ b/tests/QtQuick/Rectangle.js
@@ -1,7 +1,7 @@
 describe('QtQuick.Rectangle', function() {
   var loader = prefixedQmlLoader('QtQuick/qml/Rectangle');
   it('White', function() {
-    var div = loader('White');
+    var qml, div = loader('White').rootElement;
     expect(div.innerHTML).toBe('');
     expect(div.style.backgroundColor).toBe('white');
     expect(div.offsetWidth).toBe(200);
@@ -11,12 +11,12 @@ describe('QtQuick.Rectangle', function() {
     div.remove();
   });
   it('Color', function() {
-    var div = loader('Color');
+    var div = loader('Color').rootElement;
     expect(div.style.backgroundColor).toBe('red');
     div.remove();
   });
   it('Transparent', function() {
-    var div = loader('Transparent');
+    var div = loader('Transparent').rootElement;
     expect(div.style.backgroundColor).toBe('transparent');
     div.remove();
   });

--- a/tests/QtQuick/qml/ItemEmpty.qml
+++ b/tests/QtQuick/qml/ItemEmpty.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+
+Item {
+}

--- a/tests/QtQuick/qml/ItemSize.qml
+++ b/tests/QtQuick/qml/ItemSize.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Item {
+  width: 200
+  height: 100
+}

--- a/tests/QtQuick/qml/RectangleColor.qml
+++ b/tests/QtQuick/qml/RectangleColor.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Rectangle {
+  color: 'red'
+}

--- a/tests/QtQuick/qml/RectangleTransparent.qml
+++ b/tests/QtQuick/qml/RectangleTransparent.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Rectangle {
+  color: 'transparent'
+}

--- a/tests/QtQuick/qml/RectangleWhite.qml
+++ b/tests/QtQuick/qml/RectangleWhite.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Rectangle {
+  width: 200
+  height: 100
+}

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,3 +1,6 @@
+it.cannot = function(name, func){
+
+}
 function createQmlEngine(opts){
   var div = document.createElement('div');
   var qml = new QMLEngine(div, opts || {});

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,0 +1,14 @@
+function loadQmlFile(file, opts) {
+  var div = document.createElement('div');
+  var qml = new QMLEngine(div, opts || {});
+  qml.loadFile('/base/tests/' + file);
+  qml.start();
+  document.body.appendChild(div);
+  return div;
+}
+
+function prefixedQmlLoader(prefix) {
+  return function(file, opts) {
+    return loadQmlFile(prefix + file + '.qml', opts);
+  }
+}

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,10 +1,17 @@
+function createQmlEngine(opts){
+  var div = document.createElement('div');
+  var qml = new QMLEngine(div, opts || {});
+  qml.start()
+  return qml
+}
+
 function loadQmlFile(file, opts) {
   var div = document.createElement('div');
   var qml = new QMLEngine(div, opts || {});
   qml.loadFile('/base/tests/' + file);
   qml.start();
   document.body.appendChild(div);
-  return div;
+  return qml;
 }
 
 function prefixedQmlLoader(prefix) {

--- a/tests/common.js
+++ b/tests/common.js
@@ -19,3 +19,6 @@ function prefixedQmlLoader(prefix) {
     return loadQmlFile(prefix + file + '.qml', opts);
   }
 }
+function contextVariable(obj, name){
+  return obj.$context[name]
+}


### PR DESCRIPTION
Added some simple language tests, found an error where only the root object had its $context property set, but not its children. 
applied 9d4c4cf14fded5c4dcbc499fb7f4d862a66a988e from kde-master to make the test pass.

also added gulp task karma-debug that launches a debugger in chrome/chromium