### PR TITLE
Merge: Don't override inner component context.

### DIFF
--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -121,9 +121,6 @@ function construct(meta) {
     } else if (component = Qt.createComponent(meta.object.$class + ".qml", meta.context)) {
         var item = component.createObject(meta.parent);
 
-        // Alter objects context to the outer context
-        item.$context = meta.$context;
-
         if (typeof item.dom != 'undefined')
           item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");
         var dProp; // Handle default properties
@@ -137,7 +134,7 @@ function construct(meta) {
         meta.context[meta.object.id] = item;
 
     // Apply properties (Bindings won't get evaluated, yet)
-    applyProperties(meta.object, item, item, meta.context);
+    applyProperties(meta.object, item, item, item.$context);
 
     return item;
 }


### PR DESCRIPTION
> The construct function overrided the inner context with some empty
context. This was due to an earlier misunderstanding of how the
contexts work and was completely meaningless (except of causing bugs).
I simply removed that line now.