### PR TITLE
Reduce unneeded evals

### DIFF
--- a/src/qtcore/qml/QMLBinding.js
+++ b/src/qtcore/qml/QMLBinding.js
@@ -23,8 +23,5 @@ global.QMLBinding.prototype.toJSON = function() {
  * Compile binding. Afterwards you may call binding.eval to evaluate.
  */
 QMLBinding.prototype.compile = function() {
-    var bindSrc = this.function
-                    ? "(function(__executionObject, __executionContext) { with(__executionContext) with(__executionObject) " + this.src + "})"
-                    : "(function(__executionObject, __executionContext) { with(__executionContext) with(__executionObject) return " + this.src + "})";
-    this.eval = eval(bindSrc);
+    this.eval = new Function('__executionObject', '__executionContext', "with(__executionContext) with(__executionObject) " + ( this.function ? "" : "return " ) + this.src);
 }

--- a/src/qtcore/qml/lib/import.js
+++ b/src/qtcore/qml/lib/import.js
@@ -52,7 +52,7 @@ function parseQML(file) {
     var contents = getUrlContents(file + ".js");
     if (contents) {
         console.log("Using pre-processed content for " + file);
-        return eval("(function(){return "+contents+"})();");
+        return new Function("return " + contents)();
     } else {
         contents = getUrlContents(file);
         if (contents) {
@@ -167,9 +167,7 @@ importJs = function (filename) {
     // Make that function return an object.
     // That object contains getters and setters for exported stuff.
     // Add () to execute the function.
-    src = "(function(){"
-        + src
-        + ";return {";
+    src += ";return {";
     for (i = 0; i < exports.length; i++) {
         // create getters and setters for properties
         // keeps variables synced better
@@ -178,10 +176,10 @@ importJs = function (filename) {
         // without getters and setters:
         // src += exports[i] + ":" + exports[i] + ",";
     }
-    src += "}})()";
+    src += "}";
 
     // evaluate source to get the object.
-    return eval(src);
+    return new Function(src)();
 }
 
 /**

--- a/tests/QMLEngine/bindings.js
+++ b/tests/QMLEngine/bindings.js
@@ -1,0 +1,9 @@
+describe('QMLEngine.imports', function() {
+  var loader = prefixedQmlLoader('QMLEngine/qml/Bindings');
+  it('NoSrc', function() {
+    var div = loader('NoSrc');
+    expect(div.offsetWidth).toBe(10);
+    expect(div.offsetHeight).toBe(12);
+    div.remove();
+  });
+});

--- a/tests/QMLEngine/qml/BindingsNoSrc.qml
+++ b/tests/QMLEngine/qml/BindingsNoSrc.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Item {
+  width: 10
+  height: (typeof bindSrc === 'undefined') ? width + 2 : bindSrc.length
+}


### PR DESCRIPTION
This makes the execution scope cleaner — `eval()` captures the parent scope, `new Function()` doesn't.
A testcase to ensure that `bindSrc` not being exported to the binding scope is included (fails on master).

/cc @Plaristote, @akreuzkamp 