### PR TITLE
Get source mappings to work on coverage

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,10 +4,10 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
     files: [
       'lib/qt.js',
-      //{
-      //  pattern: 'lib/qt.js.map',
-      //  included: false
-      //},
+      {
+        pattern: 'lib/qt.js.map',
+        included: false
+      },
       'tests/common.js',
       'tests/failingTests.js',
       'tests/*/**/*.js',
@@ -24,7 +24,7 @@ module.exports = function(config) {
       dir: 'coverage/'
     },
     preprocessors: {
-      //'lib/qt.js.map': ['sourcemap'],
+      'lib/qt.js.map': ['sourcemap'],
       'lib/qt.js': ['coverage'],
 
     },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,11 +4,16 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
     files: [
       'lib/qt.js',
+      //{
+      //  pattern: 'lib/qt.js.map',
+      //  included: false
+      //},
       'tests/common.js',
       'tests/failingTests.js',
       'tests/*/**/*.js',
       { pattern: 'tests/*/**/*.qml', included: false },
-      { pattern: 'tests/*/**/*.png', included: false }
+      { pattern: 'tests/*/**/*.png', included: false },
+
     ],
     browsers: ['PhantomJSCustom'],
     reporters: process.env.COVERALLS_REPO_TOKEN ?
@@ -19,7 +24,9 @@ module.exports = function(config) {
       dir: 'coverage/'
     },
     preprocessors: {
-      'lib/qt.js': ['coverage']
+      //'lib/qt.js.map': ['sourcemap'],
+      'lib/qt.js': ['coverage'],
+
     },
     customLaunchers: {
       PhantomJSCustom: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^0.2.1",
-    "install": "^0.4.4",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-coverage": "^0.5.3",
@@ -20,7 +19,6 @@
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
-    "npm": "^3.7.3",
     "phantomjs-prebuilt": "^2.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,15 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^0.2.1",
+    "install": "^0.4.4",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-coverage": "^0.5.3",
     "karma-coveralls": "^1.1.2",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sourcemap-loader": "^0.3.7",
+    "npm": "^3.7.3",
     "phantomjs-prebuilt": "^2.1.4"
   },
   "scripts": {


### PR DESCRIPTION
Coveralls cannot show the coverage reports because lib/qt.js is not in the repo. would be nice to have.
should be possible to use the sourcemaps somehow, but cant get the package karma-sourcemap-loader to work. 
Any idea why this does not work?