### PR TITLE
adds a test to check that the js parser supports regexps

### DIFF
--- a/tests/QMLEngine/javascript.js
+++ b/tests/QMLEngine/javascript.js
@@ -4,4 +4,12 @@ describe('QMLEngine.javascript', function() {
     var div = loader('BasicSyntax');
     div.remove()
   });
+
+  it('can parse regexp', function() {
+    var qml = loader('Regexp').qml;
+    expect("toto".match(qml.reg)).toBe(null);
+    expect("4242/firstsecond".match(qml.reg)).not.toBe(null);
+    qml.dom.remove();
+  });
 });
+

--- a/tests/QMLEngine/qml/JavascriptRegexp.qml
+++ b/tests/QMLEngine/qml/JavascriptRegexp.qml
@@ -1,0 +1,3 @@
+Item {
+  property variant reg: /^[0-9]+\/(first|second){1,2}$/
+}


### PR DESCRIPTION
Related to #58, improves our code coverage by checking that the code handling regexps in our js parser does the job.