### PR TITLE
Fix parsing of properies named signal.

### DIFF
--- a/src/qtcore/qml/lib/parser.js
+++ b/src/qtcore/qml/lib/parser.js
@@ -1339,7 +1339,6 @@ function qmlparse($TEXT, exigent_mode, embed_tokens) {
         }
 
         function qmlsignaldef() {
-            next();
             var name = S.token.value;
             next();
             var args = [];
@@ -1373,7 +1372,19 @@ function qmlparse($TEXT, exigent_mode, embed_tokens) {
                 return as("qmlmethod", name, stat,
                     S.text.substr(from, to - from));
             } else if (is("name", "signal")) {
-                return qmlsignaldef();
+                next();
+                if (is("punc", ":")) {
+                    next();
+                    S.in_function++;
+                    var from = S.token.pos,
+                        stat = statement(),
+                        to = S.token.pos;
+                    S.in_function--;
+                    return as("qmlprop", propname, stat,
+                        S.text.substr(from, to - from));
+                } else {
+                    return qmlsignaldef();
+                }
             } else if (S.token.type == "name") {
                 var propname = S.token.value;
                 next();

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -20,4 +20,11 @@ describe('QMLEngine.properties', function() {
     expect(qml.childX).toBe(125);
     div.remove();
   });
+
+  it('can be named signal', function() {
+    expect(function() {
+      var div = loader('NamedSignal');
+      div.remove();
+    }).not.toThrow();
+  });
 });

--- a/tests/QMLEngine/qml/ItemWithPropertyNamedSignal.qml
+++ b/tests/QMLEngine/qml/ItemWithPropertyNamedSignal.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.5
+Item {
+  property int signal: 10
+}

--- a/tests/QMLEngine/qml/PropertiesNamedSignal.qml
+++ b/tests/QMLEngine/qml/PropertiesNamedSignal.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.5
+Item {
+  ItemWithPropertyNamedSignal {
+    signal: 20
+  }
+}


### PR DESCRIPTION
So far if you wrote "signal:" as a property name the parsing would
fail because it handle signal as a keyword. Now this case is handled
that if signal is followed by a colon it's ok and handled as a
property.

This is completely untested, as I don't have a lot of time, these days. Please be so kind and add a auto test for me. :)

Fixes #76.
