### PR TITLE
adds an options parameter to createSimpleProperty

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/SystemPalette.js
+++ b/src/qtcore/qml/elements/QtQuick/SystemPalette.js
@@ -26,7 +26,7 @@ registerQmlType({
     var platform = 'OSX';
 
     for (var i = 0 ; i < attrs.length ; ++i)
-      createSimpleProperty("color", this, attrs[i], "ro");
+      createSimpleProperty("color", this, attrs[i], { readOnly: true });
     createSimpleProperty("enum", this, "colorGroup");
 
     this.colorGroupChanged.connect(this, (function (newVal) {

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -145,16 +145,20 @@ function construct(meta) {
  * @param {String} propName Property name
  * @param {Object} [options] Options that allow finetuning of the property
  */
-function createSimpleProperty(type, obj, propName, access) {
+function createSimpleProperty(type, obj, propName, options) {
     var prop = new QMLProperty(type, obj, propName);
     var getter, setter;
-    if (typeof access == 'undefined' || access == null)
-      access = 'rw';
+
+    if (typeof options == 'undefined')
+      options = {};
+    else if (typeof options != 'object')
+      options = { default: options }
 
     obj[propName + "Changed"] = prop.changed;
     obj.$properties[propName] = prop;
+    obj.$properties[propName].set(options.default);
     getter = function()       { return obj.$properties[propName].get(); };
-    if (access == 'rw')
+    if (!options.readOnly)
       setter = function(newVal) { return obj.$properties[propName].set(newVal); };
     else {
       setter = function(newVal) {


### PR DESCRIPTION
The comment above `createSimpleProperty` spoke of an `options` parameter, which this commit now implements.

If the `options` parameter isn't an object, it'll be used as the default value. If it is an object, we look for the `readOnly` and `default` attributes to set the access policy and the default value.

This will fix the case(s?) when people have used the fourth parameter of `createSimpleProperty` to set default values (while this parameter was actually used to define the access policy).