### PR TITLE
Image: set the status after dimensions

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/Image.js
+++ b/src/qtcore/qml/elements/QtQuick/Image.js
@@ -52,15 +52,15 @@ registerQmlType({
 
     // Bind status to img element
     img.onload = function() {
-        self.progress = 1;
-        self.status = self.Image.Ready;
-
         var w = img.naturalWidth;
         var h = img.naturalHeight;
         self.sourceSize.width = w;
         self.sourceSize.height = h;
         self.implicitWidth = w;
         self.implicitHeight = h;
+
+        self.progress = 1;
+        self.status = self.Image.Ready;
     }
     img.onerror = function() {
         self.status = self.Image.Error;

--- a/tests/Render/Async/Image.qml
+++ b/tests/Render/Async/Image.qml
@@ -2,8 +2,6 @@ import QtQuick 2.0
 
 Image {
   source: 'Image.png'
-  width: 25
-  height: 25
 
   onStatusChanged: {
     if (typeof window !== 'undefined' &&


### PR DESCRIPTION
This is how Qt does things, it also gives us the correct dimensions inside the onStatusChanged callback.

The Image render tests has been modified to also check that the dimensions have been set correctly (it does not force them anymore).

/cc @Plaristote @akreuzkamp @henrikrudstrom 