### PR TITLE
fix BorderImage not filling the middle region

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/BorderImage.js
+++ b/src/qtcore/qml/elements/QtQuick/BorderImage.js
@@ -52,7 +52,8 @@ registerQmlType({
         this.dom.style.MozBorderImageSlice = this.border.top + " "
                                                 + this.border.right + " "
                                                 + this.border.bottom + " "
-                                                + this.border.left;
+                                                + this.border.left + " "
+                                                + "fill";
         this.dom.style.MozBorderImageRepeat = this.horizontalTileMode + " "
                                                     + this.verticalTileMode;
         this.dom.style.MozBorderImageWidth = this.border.top + " "
@@ -64,7 +65,8 @@ registerQmlType({
         this.dom.style.webkitBorderImageSlice = this.border.top + " "
                                                 + this.border.right + " "
                                                 + this.border.bottom + " "
-                                                + this.border.left;
+                                                + this.border.left + " "
+                                                + "fill";
         this.dom.style.webkitBorderImageRepeat = this.horizontalTileMode + " "
                                                     + this.verticalTileMode;
         this.dom.style.webkitBorderImageWidth = this.border.top + " "
@@ -76,7 +78,8 @@ registerQmlType({
         this.dom.style.OBorderImageSlice = this.border.top + " "
                                                 + this.border.right + " "
                                                 + this.border.bottom + " "
-                                                + this.border.left;
+                                                + this.border.left + " "
+                                                + "fill";
         this.dom.style.OBorderImageRepeat = this.horizontalTileMode + " "
                                                     + this.verticalTileMode;
         this.dom.style.OBorderImageWidth = this.border.top + "px "
@@ -87,7 +90,8 @@ registerQmlType({
         this.dom.style.borderImageSlice = this.border.top + " "
                                                 + this.border.right + " "
                                                 + this.border.bottom + " "
-                                                + this.border.left;
+                                                + this.border.left + " "
+                                                + "fill";
         this.dom.style.borderImageRepeat = this.horizontalTileMode + " "
                                                     + this.verticalTileMode;
         this.dom.style.borderImageWidth = this.border.top + "px "


### PR DESCRIPTION
The current implementation for BorderImages doesn't fill the middle region as described in http://doc.qt.io/qt-5/qml-qtquick-borderimage.html
Though we can't chose between repeat and scaled mode, this change allows our BorderImage object to render a little bit more like the original implementation.