### PR TITLE
Refactor tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
     browsers: ['PhantomJSCustom'],
     reporters: process.env.COVERALLS_REPO_TOKEN ?
                    ['progress', 'coverage', 'coveralls'] :
-                   ['progress', 'coverage'],
+                   ['spec', 'coverage'],
     coverageReporter: {
       type: 'lcov',
       dir: 'coverage/'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "karma-coveralls": "^1.1.2",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-spec-reporter": "~0.0.24",
     "phantomjs-prebuilt": "^2.1.4"
   },
   "scripts": {

--- a/tests/QMLEngine/bindings.js
+++ b/tests/QMLEngine/bindings.js
@@ -1,21 +1,20 @@
 describe('QMLEngine.imports', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QMLEngine/qml/Bindings');
+
   it('NoSrc', function() {
-    var div = loader('NoSrc');
+    var div = loader('NoSrc', this.div).dom;
     expect(div.offsetWidth).toBe(10);
     expect(div.offsetHeight).toBe(12);
-    div.remove();
   });
 
   it('update immediately', function() {
-    var div = loader('Update');
-    var qml = div.qml;
+    var qml = loader('Update', this.div);
     expect(qml.intB).toBe(20);
     expect(qml.textB).toBe("hello world");
     qml.intA = 5;
     expect(qml.intB).toBe(10);
     qml.textA = "goodbye";
     expect(qml.textB).toBe("goodbye world");
-    div.remove();
   });
 });

--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -1,10 +1,12 @@
 describe('QMLEngine.imports', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QMLEngine/qml/Import');
+
   it('Javascript', function() {
-    var div = loader('Javascript');
+    var qml = loader('Javascript', this.div);
+    var div = qml.dom;
     expect(div.offsetWidth).toBe(20);
     expect(div.offsetHeight).toBe(10);
     expect(div.style.backgroundColor).toBe('magenta');
-    div.remove();
   });
 });

--- a/tests/QMLEngine/javascript.js
+++ b/tests/QMLEngine/javascript.js
@@ -1,15 +1,14 @@
 describe('QMLEngine.javascript', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QMLEngine/qml/Javascript');
+
   it('can be parsed', function() {
-    var div = loader('BasicSyntax');
-    div.remove();
+    var qml = loader('BasicSyntax', this.div);
   });
 
   it('can parse regexp', function() {
-    var qml = loader('Regexp').qml;
+    var qml = loader('Regexp', this.div);
     expect("toto".match(qml.reg)).toBe(null);
     expect("4242/firstsecond".match(qml.reg)).not.toBe(null);
-    qml.dom.remove();
   });
 });
-

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -1,8 +1,9 @@
 describe('QMLEngine.properties', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QMLEngine/qml/Properties');
+
   it('can store values', function() {
-    var div = loader('Basic');
-    var qml = div.qml;
+    var qml = loader('Basic', this.div);
     expect(qml.intProperty).toBe(10);
     expect(qml.doubleProperty).toBe(0.5);
     expect(qml.stringProperty).toBe("hello");
@@ -11,20 +12,14 @@ describe('QMLEngine.properties', function() {
     expect(qml.hexProperty).toEqual(255);
     expect(qml.octProperty).toEqual(63);
     expect(qml.bigNumber).toEqual(100000000);
-    div.remove();
   });
 
   it('can be aliased', function() {
-    var div = loader('Alias');
-    var qml = div.qml;
+    var qml = loader('Alias', this.div);
     expect(qml.childX).toBe(125);
-    div.remove();
   });
 
   it('can be named signal', function() {
-    expect(function() {
-      var div = loader('NamedSignal');
-      div.remove();
-    }).not.toThrow();
+    var div = loader('NamedSignal', this.div).dom;
   });
 });

--- a/tests/QMLEngine/scope.js
+++ b/tests/QMLEngine/scope.js
@@ -3,10 +3,10 @@ function contextVariable(obj, name) {
 }
 
 describe('QMLEngine.scope', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QMLEngine/qml/Scope');
   it('can reference parent items id', function() {
-    var div = loader('Root');
-    var qml = div.qml;
+    var qml = loader('Root', this.div);
     var parentItem = contextVariable(qml, "parentItem");
     expect(parentItem).not.toBe(undefined);
     expect(parentItem.$context).not.toBe(undefined);
@@ -17,6 +17,5 @@ describe('QMLEngine.scope', function() {
     expect(childA.parentValue).toBe(100);
     expect(childA.rootValue).toBe(1000);
     expect(parentItem.sum).toBe(6600);
-    div.remove();
   });
 });

--- a/tests/QtQuick/Item.js
+++ b/tests/QtQuick/Item.js
@@ -1,17 +1,17 @@
 describe('QtQuick.Item', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QtQuick/qml/Item');
+
   it('Empty', function() {
-    var div = loader('Empty');
-    expect(div.innerHTML).toBe('');
-    expect(div.style.backgroundColor).toBe('');
-    div.remove();
+    var qml = loader('Empty', this.div);
+    expect(this.div.innerHTML).toBe('');
+    expect(this.div.style.backgroundColor).toBe('');
   });
   it('Size', function() {
-    var div = loader('Size');
-    expect(div.offsetWidth).toBe(200);
-    expect(div.offsetHeight).toBe(100);
-    expect(div.clientWidth).toBe(200);
-    expect(div.clientHeight).toBe(100);
-    div.remove();
+    var qml = loader('Size', this.div);
+    expect(this.div.offsetWidth).toBe(200);
+    expect(this.div.offsetHeight).toBe(100);
+    expect(this.div.clientWidth).toBe(200);
+    expect(this.div.clientHeight).toBe(100);
   });
 });

--- a/tests/QtQuick/Rectangle.js
+++ b/tests/QtQuick/Rectangle.js
@@ -1,23 +1,22 @@
 describe('QtQuick.Rectangle', function() {
+  setupDivElement();
   var loader = prefixedQmlLoader('QtQuick/qml/Rectangle');
+
   it('White', function() {
-    var div = loader('White');
+    var div = loader('White', this.div).dom;
     expect(div.innerHTML).toBe('');
     expect(div.style.backgroundColor).toBe('white');
     expect(div.offsetWidth).toBe(200);
     expect(div.offsetHeight).toBe(100);
     expect(div.clientWidth).toBe(200);
     expect(div.clientHeight).toBe(100);
-    div.remove();
   });
   it('Color', function() {
-    var div = loader('Color');
-    expect(div.style.backgroundColor).toBe('red');
-    div.remove();
+    var qml = loader('Color', this.div);
+    expect(this.div.style.backgroundColor).toBe('red');
   });
   it('Transparent', function() {
-    var div = loader('Transparent');
-    expect(div.style.backgroundColor).toBe('transparent');
-    div.remove();
+    var qml = loader('Transparent', this.div);
+    expect(this.div.style.backgroundColor).toBe('transparent');
   });
 });

--- a/tests/Render/runner.js
+++ b/tests/Render/runner.js
@@ -84,9 +84,10 @@
 
   Object.keys(tests).forEach(function(group) {
     describe('Render.' + group, function() {
+      setupDivElement();
       tests[group].forEach(function(test) {
         it(test.name, function(done) {
-          var div = loadQmlFile(test.qml);
+          var div = loadQmlFile(test.qml, this.div).dom;
           var result, expected, loaded = 0;
 
           var process = function() {
@@ -104,7 +105,6 @@
               fileName: test.group + '/' + test.name + '.png'
             });
             result.onload = process;
-            div.remove();
           };
 
           if (group.indexOf('Async') !== -1) {

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,10 +1,9 @@
-function loadQmlFile(file, opts) {
-  var div = document.createElement('div');
-  var qml = new QMLEngine(div, opts || {});
-  qml.loadFile(file);
-  qml.start();
+function loadQmlFile(file, div, opts) {
+  var engine = new QMLEngine(div, opts || {});
+  engine.loadFile(file);
+  engine.start();
   document.body.appendChild(div);
-  return div;
+  return engine.rootObject;
 }
 
 function prefixedQmlLoader(prefix) {
@@ -20,6 +19,15 @@ function loadQml(src, opts) {
   qml.start();
   document.body.appendChild(div);
   return qml;
+}
+
+function setupDivElement() {
+  beforeEach(function() {
+    this.div = document.createElement('div');
+  });
+  afterEach(function() {
+    this.div.remove();
+  });
 }
 
 (function() {


### PR DESCRIPTION
moved the `div` creating and removal code to `beforeEach` and `afterEach`

just add `setupDivElement();` to your test

```
describe('QMLEngine.scope', function() {
  setupDivElement();
```