### PR TITLE
White background for test screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/
 *.kdev4
 *kate-swp
 .idea
+dev
+*.autosave

--- a/qmlweb-dev-install.bat
+++ b/qmlweb-dev-install.bat
@@ -1,0 +1,4 @@
+git clone https://github.com/qmlweb/qmlweb-dev.git dev
+cd dev
+build.bat
+cd ..

--- a/qmlweb-dev-install.sh
+++ b/qmlweb-dev-install.sh
@@ -1,0 +1,4 @@
+git clone https://github.com/qmlweb/qmlweb-dev.git dev
+cd dev
+./build.sh
+cd ..

--- a/tests/Render/runner.js
+++ b/tests/Render/runner.js
@@ -34,6 +34,8 @@
     var ctx = canvas.getContext('2d');
     canvas.height = img.height;
     canvas.width = img.width;
+    ctx.fillStyle = "rgb(255,255,255)";
+    ctx.fillRect (0,0, canvas.width,canvas.height);
     ctx.drawImage(img, 0, 0);
     return ctx.getImageData(0, 0, img.height, img.width).data;
   }


### PR DESCRIPTION
the screenshot utility in qmlweb-dev has white background for all screenshots. the screenshot function in js sometimes creates transparent background. would like the outputs to match.
I dont believe there is any testcases we cannot test with white background, correct me if im wrong!
@ChALkeR 