### PR TITLE
eliminate Undefined and replace references with undefined

### DIFF
--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -625,7 +625,7 @@ QMLEngine = function (element, options) {
         console = {};
         console.log = function() {
             var args = Array.prototype.slice.call(arguments);
-            options.debugConsole.apply(Undefined, args);
+            options.debugConsole.apply(undefined, args);
         };
     }
 }

--- a/src/qtcore/qml/elements/QtQuick/Font.js
+++ b/src/qtcore/qml/elements/QtQuick/Font.js
@@ -21,7 +21,7 @@ registerQmlType({
         });
         this.boldChanged.connect(function(newVal) {
             parent.dom.firstChild.style.fontWeight =
-                parent.font.weight !== Undefined ? parent.font.weight :
+                parent.font.weight !== undefined ? parent.font.weight :
                 newVal ? "bold" : "normal";
         });
         this.capitalizationChanged.connect(function(newVal) {
@@ -37,16 +37,16 @@ registerQmlType({
             parent.dom.firstChild.style.fontStyle = newVal ? "italic" : "normal";
         });
         this.letterSpacingChanged.connect(function(newVal) {
-            parent.dom.firstChild.style.letterSpacing = newVal !== Undefined ? newVal + "px" : "";
+            parent.dom.firstChild.style.letterSpacing = newVal !== undefined ? newVal + "px" : "";
         });
         this.pixelSizeChanged.connect(function(newVal) {
-            var val = newVal !== Undefined ? newVal + "px "
+            var val = newVal !== undefined ? newVal + "px "
                 : (parent.font.pointSize || 10) + "pt";
             parent.dom.style.fontSize = val;
             parent.dom.firstChild.style.fontSize = val;
         });
         this.pointSizeChanged.connect(function(newVal) {
-            var val = parent.font.pixelSize !== Undefined ? parent.font.pixelSize + "px "
+            var val = parent.font.pixelSize !== undefined ? parent.font.pixelSize + "px "
                 : (newVal || 10) + "pt";
             parent.dom.style.fontSize = val;
             parent.dom.firstChild.style.fontSize = val;
@@ -67,11 +67,11 @@ registerQmlType({
         });
         this.weightChanged.connect(function(newVal) {
             parent.dom.firstChild.style.fontWeight =
-                newVal !== Undefined ? newVal :
+                newVal !== undefined ? newVal :
                 parent.font.bold ? "bold" : "normal";
         });
         this.wordSpacingChanged.connect(function(newVal) {
-            parent.dom.firstChild.style.wordSpacing = newVal !== Undefined ? newVal + "px" : "";
+            parent.dom.firstChild.style.wordSpacing = newVal !== undefined ? newVal + "px" : "";
         });
   }
 });

--- a/src/qtcore/qml/elements/QtQuick/NumberAnimation.js
+++ b/src/qtcore/qml/elements/QtQuick/NumberAnimation.js
@@ -31,7 +31,7 @@ registerQmlType({
     function startLoop() {
         for (var i in this.$actions) {
             var action = this.$actions[i];
-            action.from = action.from !== Undefined ? action.from : action.target[action.property];
+            action.from = action.from !== undefined ? action.from : action.target[action.property];
         }
         at = 0;
     }

--- a/src/qtcore/qml/elements/QtQuick/Text.js
+++ b/src/qtcore/qml/elements/QtQuick/Text.js
@@ -22,10 +22,10 @@ registerQmlType({
             || font.weight == Font.DemiBold
             || font.weight == Font.Black
             || font.bold) ? "bold " : "normal ";
-        css += font.pixelSize !== Undefined
+        css += font.pixelSize !== undefined
             ? font.pixelSize + "px "
             : (font.pointSize || 10) + "pt ";
-        css += this.lineHeight !== Undefined ? this.lineHeight + "px " : " ";
+        css += this.lineHeight !== undefined ? this.lineHeight + "px " : " ";
         css += (font.family || "sans-serif") + " ";
         return css;
     }
@@ -160,7 +160,7 @@ registerQmlType({
     function updateImplicitHeight() {
         var height;
 
-        if (this.text === Undefined || this.text === "") {
+        if (this.text === undefined || this.text === "") {
             height = 0;
         } else {
             height = this.dom ? this.dom.firstChild.offsetHeight : 0;
@@ -172,7 +172,7 @@ registerQmlType({
     function updateImplicitWidth() {
         var width;
 
-        if (this.text === Undefined || this.text === "")
+        if (this.text === undefined || this.text === "")
             width = 0;
         else
             width = this.dom ? this.dom.firstChild.offsetWidth : 0;

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -1,6 +1,5 @@
 var GETTER = "__defineGetter__",
     SETTER = "__defineSetter__",
-    Undefined = undefined,
     // Property that is currently beeing evaluated. Used to get the information
     // which property called the getter of a certain other property for
     // evaluation and is thus dependant on it.


### PR DESCRIPTION
This is actually a good change. You can't override `undefined` nowdays, so there is no use in saving it in a separate variable.