### PR TITLE
Fix render tests

### DIFF
--- a/tests/Render/Simple/RectangleBorder.qml
+++ b/tests/Render/Simple/RectangleBorder.qml
@@ -13,7 +13,7 @@ Rectangle {
     width: 11
     height: 10
     x: 15
-    radius: 2
+    border.color: 'red'
   }
   Rectangle {
     width: 10

--- a/tests/Render/runner.js
+++ b/tests/Render/runner.js
@@ -35,24 +35,14 @@
     canvas.height = img.height;
     canvas.width = img.width;
     ctx.drawImage(img, 0, 0);
-    return ctx.getImageData(0, 0, img.height, img.width).data;
+    return canvas.toDataURL('image/png', 1);
   }
 
   function imagesEqual(a, b) {
     if (a.width !== b.width || a.height !== b.height)
       return false;
 
-    a = image2data(a);
-    b = image2data(b);
-
-    if (a.length !== b.length)
-      return false;
-
-    for (var i = 0; i < a.length; i++)
-      if (a[i] !== b[i])
-        return false;
-
-    return true;
+    return image2data(a) === image2data(b);
   }
 
   function delayedFrames(callback, frames) {


### PR DESCRIPTION
There was an mistake where render tests were erroneously passing when they should fail.
That happened because `.getImageData()` was returning partial result (the image was not painted yet).

Also this fixes my merge error in the `RectangleBorder` render test.

/cc @henrikrudstrom @igosoft 