### PR TITLE
Set box-sizing: border-box on all Items

### DIFF
--- a/src/qtcore/qml/elements/Item.js
+++ b/src/qtcore/qml/elements/Item.js
@@ -24,6 +24,8 @@ function QMLItem(meta) {
     this.dom.qml = this;
     this.css = this.dom.style;
 
+    this.css.boxSizing = 'border-box';
+
     createSimpleProperty("list", this, "data");
     this.$defaultProperty = "data";
     createSimpleProperty("list", this, "children");

--- a/src/qtcore/qml/elements/QtQuick/Rectangle.js
+++ b/src/qtcore/qml/elements/QtQuick/Rectangle.js
@@ -33,7 +33,6 @@ registerQmlType({
     this.radius = 0;
     this.css.borderWidth ='0px';
     this.css.borderStyle = 'solid';
-    this.css.boxSizing = 'border-box';
     this.css.borderColor = 'black';
 
     this.$drawItem = function(c) {

--- a/tests/Initialize/runner.js
+++ b/tests/Initialize/runner.js
@@ -71,6 +71,7 @@ testModule(modules, function(module, element, imports, options) {
         expect(this.div.className).toBe(element);
         expect(this.div.qml).not.toBe(undefined);
         expect(this.div.qml).toBe(qml);
+        expect(this.div.style.boxSizing).toBe('border-box');
       }
       expect(qml.Component).not.toBe(undefined);
     });


### PR DESCRIPTION
This uses inheritance to ensure that all QML DOM items will have `box-sizing: border-box`.
It also modified `Initialize` tests to check that.

See #90 and #110.