### PR TITLE
Repeater: remove unneeded line

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/Repeater.js
+++ b/src/qtcore/qml/elements/QtQuick/Repeater.js
@@ -122,7 +122,6 @@ function QMLRepeater(meta) {
         var removed = self.$items.splice(startIndex, endIndex - startIndex);
         for (var index in removed) {
             removed[index].$delete();
-            removed[index].parent = undefined;
             removeChildProperties(removed[index]);
         }
     }


### PR DESCRIPTION
Manual `.parent` unsetting after `.$delete()` is not needed anymore due to 66222bc6cfb361c07602b8581ca21940a9309d14.

/cc @pavelvasev 