### PR TITLE
test: cannot parse function assigned to var property

### DIFF
--- a/tests/QMLEngine/parse.js
+++ b/tests/QMLEngine/parse.js
@@ -13,4 +13,9 @@ describe('QMLEngine.parse', function() {
     expect(exception.comment).toContain("properly int error");
     expect(exception.line).toBe(4);
   });
+
+  it("can parse a function assigned to a var property", function() {
+    var qml = load('FunctionVar', this.div);
+    expect(typeof qml.aFunction).toBe("function");
+  });
 });

--- a/tests/QMLEngine/qml/ParseFunctionVar.qml
+++ b/tests/QMLEngine/qml/ParseFunctionVar.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Item {
+  property var aFunction: function(){}
+}

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -9,6 +9,9 @@ window.failingTests = {
     ]
   },
   QMLEngine: {
+    parse: [
+      'can parse a function assigned to a var property'
+    ],
     imports: [
       'Javascript',
       'RecursiveInit',


### PR DESCRIPTION
this works in qt qml but not in webqml: 
`property var aFunction: function(){}`