### PR TITLE
print qml parse error in stacktrace

### DIFF
--- a/src/qtcore/qml/lib/parser.js
+++ b/src/qtcore/qml/lib/parser.js
@@ -269,25 +269,24 @@ function parse_js_number(num) {
         }
 };
 
-function JS_Parse_Error(message, line, col, pos, comment) {
-        this.message = message;
-        this.line = line + 1;
+function QMLParseError(message, line, col, pos, comment) {
+        line = line + 1
+        this.line = line;
         this.col = col;
         this.pos = pos;
         this.comment = comment ? comment : "";
+        this.message = message + " (line: " + line + ", col: " + col + ", pos: " + pos + ")" + "\n" + comment + "\n"
         try {
                 ({})();
         } catch(ex) {
                 this.stack = ex.stack;
         };
-};
 
-JS_Parse_Error.prototype.toString = function() {
-        return this.message + " (line: " + this.line + ", col: " + this.col + ", pos: " + this.pos + ")" + "\n" + this.comment + "\n" + this.stack;
 };
+QMLParseError.prototype = new Error();
 
 function js_error(message, line, col, pos, comment) {
-        throw new JS_Parse_Error(message, line, col, pos, comment);
+        throw new QMLParseError(message, line, col, pos, comment);
 };
 
 function is_token(token, type, val) {
@@ -302,7 +301,7 @@ function extractLinesForErrorDiag(text, line)
   for (var i = line - 3; i <= line + 3; i++)
   if (i >= 0 && i < lines.length ) {
       var mark = ( i == line ) ? ">>" : "  ";
-      r += mark + i + "  " + lines[i] + "\n";
+      r += mark + (i + 1) + "  " + lines[i] + "\n";
   }
 
   return r;

--- a/tests/QMLEngine/parse.js
+++ b/tests/QMLEngine/parse.js
@@ -10,7 +10,9 @@ describe('QMLEngine.parse', function() {
       exception = e;
     }
     expect(exception).not.toBe(null);
-    expect(exception.comment).toContain("properly int error");
+    expect(exception.message).toContain("properly int error:");
+    expect(exception.message).toContain("Unexpected token name");
+    expect(exception.message).toContain("line: 4");
     expect(exception.line).toBe(4);
   });
 


### PR DESCRIPTION
Prints the error like this:
```
1) QML TEST: SimpleRenderTest
     Test.TestCase
     Error: Unexpected token: punc (() (line: 6, col: 23, pos: 83)
  3      id: test
  4      delay: 200
  5
>>6      startTest: function(){
  7          test.compareRender("", function(equal){
  8              expect(equal).toBe(true);
  9              testDone();

 (line 7)
JS_Parse_Error@/home/henrik/Development/qmlweb/lib/qt.js:9:167246
js_error@/home/henrik/Development/qmlweb/lib/qt.js:9:167557
...
...
```

Both lib/parser.js and uglify/parse.js defines `Js_Parse_Error` so i had to delete one, not sure which one.. this will be temporary until we resolve #140