### PR TITLE
Throw error instead of logging when Qml constructor is not found

### DIFF
--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -155,8 +155,7 @@ function construct(meta) {
                 item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");
             var dProp; // Handle default properties
         } else {
-            console.log("No constructor found for " + meta.object.$class);
-            return;
+            throw new Error("No constructor found for " + meta.object.$class);
         }
     }
 


### PR DESCRIPTION
Im not a big fan of failing silently, is there any reason not to throw more errors?