### PR TITLE
using qrc with readQmlDir to cache qmldir files

### DIFF
--- a/src/qtcore/qml/lib/import.js
+++ b/src/qtcore/qml/lib/import.js
@@ -129,7 +129,9 @@ readQmlDir = function (url) {
     // Q1: when this happen?
     var qmldirFileUrl = url.length > 0 ? (url + "/qmldir") : "qmldir";
 
-    var qmldir = getUrlContents( qmldirFileUrl, true), // loading url contents with skipping errors
+    if (!qrc.includesFile(qmldirFileUrl))
+      qrc[qmldirFileUrl] = getUrlContents(qmldirFileUrl, true); // loading url contents with skipping errors
+    var qmldir = qrc[qmldirFileUrl],
         lines,
         line,
         internals = {},


### PR DESCRIPTION
Allows gulp-qmlweb to aggregate the qmldir files within the qrc object.
No changes required in gulp-qmlweb for this to work, although I'll update the README to have the default file matchers look like this:
```
var qmlFiles = [ 'qml/**/*.qml', 'qml/**/*.js', 'qml/**/qmldir' ];
```
This is all that's needed to make this work with gulp-qmlweb.