### PR TITLE
Merge "properly remove animations at overwriting on init."

### DIFF
--- a/src/qmlweb/RestModel.js
+++ b/src/qmlweb/RestModel.js
@@ -141,7 +141,7 @@ registerQmlType({
     function updatePropertiesFromResponseObject(responseObject) {
       for (var key in responseObject) {
         if (responseObject.hasOwnProperty(key) && self.$hasProperty(key)) {
-          self.$properties[key].set(responseObject[key]);
+          self.$properties[key].set(responseObject[key], QMLProperty.ReasonUser);
         }
       }
     }

--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -483,6 +483,8 @@ QMLEngine = function (element, options) {
         // Initialize property bindings
         for (var i = 0; i < this.bindedProperties.length; i++) {
             var property = this.bindedProperties[i];
+            if (!property.binding)
+              continue; // Probably, the binding was overwritten by an explicit value. Ignore.
             property.binding.compile();
             property.update();
         }

--- a/src/qtcore/qml/QMLProperty.js
+++ b/src/qtcore/qml/QMLProperty.js
@@ -14,6 +14,10 @@ function QMLProperty(type, obj, name) {
     this.$tidyupList = [];
 }
 
+QMLProperty.ReasonUser = 0;
+QMLProperty.ReasonInit = 1;
+QMLProperty.ReasonAnimation = 2;
+
 // Updater recalculates the value of a property if one of the
 // dependencies changed
 QMLProperty.prototype.update = function() {
@@ -50,7 +54,7 @@ QMLProperty.prototype.get = function() {
 }
 
 // Define setter
-QMLProperty.prototype.set = function(newVal, fromAnimation, objectScope, componentScope) {
+QMLProperty.prototype.set = function(newVal, reason, objectScope, componentScope) {
     var i,
         oldVal = this.val;
 
@@ -73,7 +77,7 @@ QMLProperty.prototype.set = function(newVal, fromAnimation, objectScope, compone
             return;
         }
     } else {
-        if (!fromAnimation)
+        if (!reason != QMLProperty.ReasonAnimation)
             this.binding = null;
         if (newVal instanceof Array)
             newVal = newVal.slice(); // Copies the array
@@ -93,7 +97,7 @@ QMLProperty.prototype.set = function(newVal, fromAnimation, objectScope, compone
     }
 
     if (this.val !== oldVal) {
-        if (this.animation && !fromAnimation) {
+        if (this.animation && reason == QMLProperty.ReasonUser) {
             this.animation.running = false;
             this.animation.$actions = [{
                 target: this.animation.target || this.obj,
@@ -103,7 +107,7 @@ QMLProperty.prototype.set = function(newVal, fromAnimation, objectScope, compone
             }];
             this.animation.running = true;
         }
-        if (this.obj.$syncPropertyToRemote instanceof Function && !fromAnimation) { // is a remote object from e.g. a QWebChannel
+        if (this.obj.$syncPropertyToRemote instanceof Function && reason == QMLProperty.ReasonUser) { // is a remote object from e.g. a QWebChannel
             this.obj.$syncPropertyToRemote(this.name, newVal);
         } else {
             this.changed(this.val, oldVal, this.name);

--- a/src/qtcore/qml/elements/Item.js
+++ b/src/qtcore/qml/elements/Item.js
@@ -223,7 +223,7 @@ function QMLItem(meta) {
         // before we fetch the values because properties can be interdependent.
         for (i in actions) {
             var action = actions[i];
-            action.target.$properties[action.property].set(action.value, false, action.target,
+            action.target.$properties[action.property].set(action.value, QMLProperty.ReasonUser, action.target,
                                                            newState ? newState.$context: action.target.$context);
         }
         for (i in actions) {

--- a/src/qtcore/qml/elements/QtQuick/NumberAnimation.js
+++ b/src/qtcore/qml/elements/QtQuick/NumberAnimation.js
@@ -24,7 +24,7 @@ registerQmlType({
                 for (var i in self.$actions) {
                     var action = self.$actions[i],
                         value = self.easing.$valueForProgress(at) * (action.to - action.from) + action.from;
-                    action.target.$properties[action.property].set(value, true);
+                    action.target.$properties[action.property].set(value, QMLProperty.ReasonAnimation);
                 }
         }
     }
@@ -52,7 +52,7 @@ registerQmlType({
     this.complete = function() {
         for (var i in this.$actions) {
             var action = this.$actions[i];
-            action.target.$properties[action.property].set(action.to, true);
+            action.target.$properties[action.property].set(action.to, QMLProperty.ReasonAnimation);
         }
 
         if (++loop == this.loops)

--- a/src/qtcore/qml/elements/QtQuick/Repeater.js
+++ b/src/qtcore/qml/elements/QtQuick/Repeater.js
@@ -37,7 +37,7 @@ function QMLRepeater(meta) {
             for (var i in model.roleNames) {
                 if (typeof newItem.$properties[model.roleNames[i]] == 'undefined')
                   createSimpleProperty("variant", newItem, model.roleNames[i]);
-                newItem.$properties[model.roleNames[i]].set(model.data(index, model.roleNames[i]), true, newItem, self.model.$context);
+                newItem.$properties[model.roleNames[i]].set(model.data(index, model.roleNames[i]), QMLProperty.ReasonInit, newItem, self.model.$context);
             }
 
             self.container().children.splice(self.parent.children.indexOf(self) - self.$items.length + index, 0, newItem);
@@ -71,7 +71,7 @@ function QMLRepeater(meta) {
                     roles = model.roleNames;
                 for (var index = startIndex; index <= endIndex; index++) {
                     for (var i in roles) {
-                        self.$items[index].$properties[roles[i]].set(model.data(index, roles[i]), true, self.$items[index], self.model.$context);
+                        self.$items[index].$properties[roles[i]].set(model.data(index, roles[i]), QMLProperty.ReasonInit, self.$items[index], self.model.$context);
                     }
                 }
             });

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -193,12 +193,12 @@ function createSimpleProperty(type, obj, propName, options) {
     obj.$properties[propName].set(options.default);
     getter = function()       { return obj.$properties[propName].get(); };
     if (!options.readOnly)
-      setter = function(newVal) { return obj.$properties[propName].set(newVal); };
+      setter = function(newVal) { return obj.$properties[propName].set(newVal, QMLProperty.ReasonUser); };
     else {
       setter = function(newVal) {
         if (obj.$canEditReadOnlyProperties != true)
           throw "property '" + propName + "' has read only access";
-        return obj.$properties[propName].set(newVal);
+        return obj.$properties[propName].set(newVal, QMLProperty.ReasonUser);
       }
     }
     setupGetterSetter(obj, propName, getter, setter);
@@ -318,15 +318,15 @@ function applyProperties(metaObject, item, objectScope, componentScope) {
                     var obj = this.componentScope[this.val.objectName];
                     return this.val.propertyName ? obj.$properties[this.val.propertyName].get() : obj;
                 }
-                item.$properties[i].set = function(newVal, fromAnimation, objectScope, componentScope) {
+                item.$properties[i].set = function(newVal, reason, objectScope, componentScope) {
                     if (!this.val.propertyName)
                         throw "Cannot set alias property pointing to an QML object.";
-                    this.componentScope[this.val.objectName].$properties[this.val.propertyName].set(newVal, fromAnimation, objectScope, componentScope);
+                    this.componentScope[this.val.objectName].$properties[this.val.propertyName].set(newVal, reason, objectScope, componentScope);
                 }
                 continue;
             } else if (value instanceof QMLPropertyDefinition) {
                 createSimpleProperty(value.type, item, i);
-                item.$properties[i].set(value.value, true, objectScope, componentScope);
+                item.$properties[i].set(value.value, QMLProperty.ReasonInit, objectScope, componentScope);
                 continue;
             } else if (item[i] && value instanceof QMLMetaPropertyGroup) {
                 // Apply properties one by one, otherwise apply at once
@@ -335,7 +335,7 @@ function applyProperties(metaObject, item, objectScope, componentScope) {
             }
         }
         if (item.$properties && i in item.$properties)
-            item.$properties[i].set(value, true, objectScope, componentScope);
+            item.$properties[i].set(value, QMLProperty.ReasonInit, objectScope, componentScope);
         else if (i in item)
             item[i] = value;
         else if (item.$setCustomData)
@@ -345,7 +345,7 @@ function applyProperties(metaObject, item, objectScope, componentScope) {
     }
     if (metaObject.$children && metaObject.$children.length !== 0) {
         if (item.$defaultProperty)
-            item.$properties[item.$defaultProperty].set(metaObject.$children, true, objectScope, componentScope);
+            item.$properties[item.$defaultProperty].set(metaObject.$children, QMLProperty.ReasonInit, objectScope, componentScope);
         else
             throw "Cannot assign to unexistant default property";
     }


### PR DESCRIPTION
> During initialization it can happen that a property gets assigned a
> binding and later, still during init, gets assigned a constant value.
> In this case it wouldn't properly remove the binding and when later,
> during evaluating bindings phase, the constant value would get
> overwritten again, by the binding. This is not intended.
> 
> Now it's cleaned correctly.

Apart from one change, this merge was just about moving some code around.

Though I found a single line of code that still used the property setter function while using the `fromAnimation` parameter instead of the `reason` parameter introduced in this commit. It's the change I made to, `src/qtcore/qml/elements/Item.js`, using QMLProperty.ReasonUser as a parameter. I figured it was the right value to use in that context.