### PR TITLE
gulpfile: Clear QT_QPA_PLATFORM env var for PhantomJS to work

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,10 @@ var tests = [
   'tests/**/*.js'
 ];
 
+// This is required because other values confuse PhantomJS, and are sometimes
+// set by default by the system.
+process.env.QT_QPA_PLATFORM = '';
+
 gulp.task('build-dev', function() {
   return gulp.src(qtcoreSources)
              .pipe(order(qtcoreSources, { base: __dirname }))


### PR DESCRIPTION
`QT_QPA_PLATFORM=xcb` is set by default in some systems now, e.g. Arch Linux, and that causes PhantomJS to fail.

Ref: https://github.com/ariya/phantomjs/issues/14061

This could be reverted after it gets fixed on PhantomJS side.