### PR TITLE
gulpfile: Cleanup qtcoreSources

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,19 +11,12 @@ var karma = require('karma');
 var qtcoreSources = [
   'src/helpers/encapsulate.begin.js',
   'src/qtcore/qml/QMLBinding.js',
-
   'src/qtcore/qml/lib/parser.js',
   'src/qtcore/qml/lib/process.js',
   'src/qtcore/qml/lib/import.js',
-
-  'src/qtcore/qrc.js',
-  'src/qtcore/qt.js',
-  'src/qtcore/signal.js',
-  'src/qtcore/font.js',
-  'src/qtcore/easing.js',
+  'src/qtcore/*.js',
   'src/qtcore/qml/qml.js',
   'src/qtcore/qml/**/*.js',
-
   'src/qmlweb/**/*.js',
   'src/helpers/encapsulate.end.js'
 ];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,10 +12,6 @@ var qtcoreSources = [
   'src/helpers/encapsulate.begin.js',
   'src/qtcore/qml/QMLBinding.js',
 
-  'src/uglify/ast.js',
-  'src/uglify/parse.js',
-  'src/uglify/utils.js',
-
   'src/qtcore/qml/lib/parser.js',
   'src/qtcore/qml/lib/process.js',
   'src/qtcore/qml/lib/import.js',


### PR DESCRIPTION
This removes the `src/uglify/*` leftovers from the gulpfile (ref: #153) and merges `src/qtcore/*.js` into a single entry, they are all independant.

Note that `src/qtcore/*.js` is not the same as `src/qtcore/**/*.js` and is limited to a single level.
