### PR TITLE
Merge «Add property 'pressedButtons' to MouseArea»

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/MouseArea.js
+++ b/src/qtcore/qml/elements/QtQuick/MouseArea.js
@@ -22,6 +22,8 @@ registerQmlType({
     createSimpleProperty("real", this, "mouseY");
     createSimpleProperty("bool", this, "pressed");
     createSimpleProperty("bool", this, "containsMouse");
+    createSimpleProperty("variant", this, "pressedButtons");
+
     this.clicked = Signal([{type: "variant", name: "mouse"}]);
     this.entered = Signal();
     this.exited = Signal();
@@ -65,9 +67,11 @@ registerQmlType({
             self.mouseY = mouse.y;
             self.pressed = true;
         }
+        this.pressedButtons = mouse.button;
     }
     this.dom.onmouseup = function(e) {
         self.pressed = false;
+        this.pressedButtons = 0;
     }
     this.dom.onmouseover = function(e) {
         self.containsMouse = true;


### PR DESCRIPTION
See #49.

/cc @shry15harsh 

This doesn't support multiple buttons yet, but LGTM.

Multiple buttons are supported by Firefox, Chrome (since 43) and Edge nowdays, so this change could be extended to determine if `.buttons` is present and fallback to the implementation currently proposed by this PR.