### PR TITLE
Repeater: pass on the Component.completed() signal to all children.

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/Repeater.js
+++ b/src/qtcore/qml/elements/QtQuick/Repeater.js
@@ -25,8 +25,9 @@ function QMLRepeater(meta) {
 
     function callOnCompleted(child) {
         child.Component.completed();
-        for (var i = 0; i < child.children.length; i++)
-            callOnCompleted(child.children[i]);
+        for (var i = 0; i < child.$tidyupList.length; i++)
+            if (child.$tidyupList[i] instanceof QMLBaseObject)
+                callOnCompleted(child.$tidyupList[i]);
     }
     function insertChildren(startIndex, endIndex) {
         for (var index = startIndex; index < endIndex; index++) {


### PR DESCRIPTION
Extracted from 2865c68cd7b5fc4865b8db474c1d9cc75eaf8c23.

Comment by @akreuzkamp:
> $tidyupList is a list of internal children (compare to QObject::children() in contrast to QQuickItem::children()!). It's called tidyupList because it's main use is to remove references to child objects when deleting an object. The whole concept of memory management QmlWeb uses so far is in great need of improvement.
In short: It passes on the Component.completed() signal to all it's children.

I still don't understand this completely, and this needs a review by someone.

/cc @akreuzkamp, @Plaristote, @pavelvasev 