### PR TITLE
failing test case

### DIFF
--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -34,6 +34,14 @@ describe('QMLEngine.properties', function() {
     expect(qml.log).toBe("childX changed to 44!");
   });
 
+  it('alias propagates it\'s changed signal back to referenced property',
+    function() {
+      var qml = load('AliasChangedBack', this.div);
+      qml.go();
+      expect(qml.thechild.x).toBe(100);
+    }
+  );
+
   it('alias to id', function() {
     var qml = load('AliasToId', this.div);
     expect(qml.childA.x).toBe(125);

--- a/tests/QMLEngine/qml/PropertiesAliasChangedBack.qml
+++ b/tests/QMLEngine/qml/PropertiesAliasChangedBack.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.0
+import QtQuick.Controls 1.1
+
+Item {
+  property alias thechild: child
+  property alias childData: child.somedata
+
+  Rectangle {
+    id: child
+    x: somedata[0]
+    y: somedata[1]
+    property var somedata: [0,0]
+
+    color: "red"; width: 64; height: 64
+  }
+
+  function go() {
+    childData[0] = 100;
+    childDataChanged();
+  }
+
+  Column {
+    Button {
+      text: "go!"
+      onClicked: go();
+    }
+  }
+}

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -19,6 +19,7 @@ window.failingTests = {
     ],
     properties: [
       'alias have changed signal',
+      'alias propagates it\'s changed signal back to referenced property',
       'alias to id with same name',
       'ChangedExpressionSignal',
       'StringConversion',


### PR DESCRIPTION
 The changed signal of alias must call it's target property changed signal. Good for arrays modifications and manual changed invocation, when set is not used.

topic aliaschangeback at
https://github.com/qmlweb/qmlweb/issues/32#issuecomment-190834951