### PR TITLE
Remove canvas backend leftovers

### DIFF
--- a/src/qtcore/qml/QMLBaseObject.js
+++ b/src/qtcore/qml/QMLBaseObject.js
@@ -4,7 +4,6 @@ function QMLBaseObject(meta) {
     var i,
         prop;
 
-    this.$draw = function(){};
     this.$isComponentRoot = meta.isComponentRoot;
     this.$context = meta.context;
 

--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -489,15 +489,6 @@ QMLEngine = function (element, options) {
         this.bindedProperties = [];
     }
 
-    this.$getTextMetrics = function(text, fontCss)
-    {
-        canvas.save();
-        canvas.font = fontCss;
-        var metrics = canvas.measureText(text);
-        canvas.restore();
-        return metrics;
-    }
-
     // Return a path to load the file
     this.$resolvePath = function(file)
     {
@@ -534,12 +525,6 @@ QMLEngine = function (element, options) {
     this.size = function()
     {
         return { width: this.rootObject.getWidth(), height: this.rootObject.getHeight() };
-    }
-
-    // Performance measurements
-    this.$perfDraw = function(canvas)
-    {
-        this.rootObject.$draw(canvas);
     }
 
 //----------Private Methods----------

--- a/src/qtcore/qml/elements/Item.js
+++ b/src/qtcore/qml/elements/Item.js
@@ -356,35 +356,6 @@ function QMLItem(meta) {
             this.implicitWidth = this.dom.offsetWidth;
         }
     }
-
-    this.$draw = function(c) {
-        var i;
-        if (this.visible !== false) { // Undefined means inherit, means true
-            if (this.$drawItem ) {
-                var rotRad = (this.rotation || 0) / 180 * Math.PI,
-                    rotOffsetX = Math.sin(rotRad) * this.width,
-                    rotOffsetY = Math.sin(rotRad) * this.height;
-                c.save();
-
-                // Handle rotation
-                // todo: implement transformOrigin
-                c.globalAlpha = this.opacity;
-                c.translate(this.left + rotOffsetX, this.top + rotOffsetY);
-                c.rotate(rotRad);
-                c.translate(-this.left, -this.top);
-                // Leave offset for drawing...
-                this.$drawItem(c);
-                c.translate(-rotOffsetX, -rotOffsetY);
-                c.restore();
-            }
-            for (i = 0; i < this.children.length; i++) {
-                if (this.children[i]
-                    && this.children[i].$draw) {
-                    this.children[i].$draw(c);
-                }
-            }
-        }
-    }
 }
 inherit(QMLItem, QMLBaseObject);
 

--- a/src/qtcore/qml/elements/QtQuick/Image.js
+++ b/src/qtcore/qml/elements/QtQuick/Image.js
@@ -127,17 +127,6 @@ function QMLImage(meta) {
 
     this.mirrorChanged.connect  (this, updateMirroring);
     this.fillModeChanged.connect(this, updateFillMode);
-    this.$drawItem = function(c) {
-        updateFillMode();
-
-        if (this.status == this.Image.Ready) {
-            c.save();
-            c.drawImage(img, this.left, this.top, this.width, this.height);
-            c.restore();
-        } else {
-            console.log("Waiting for image to load");
-        }
-    }
 }
 
 registerQmlType({

--- a/src/qtcore/qml/elements/QtQuick/Rectangle.js
+++ b/src/qtcore/qml/elements/QtQuick/Rectangle.js
@@ -35,33 +35,5 @@ registerQmlType({
     this.css.borderWidth ='0px';
     this.css.borderStyle = 'solid';
     this.css.borderColor = 'black';
-
-    this.$drawItem = function(c) {
-        c.save();
-        c.fillStyle = this.color;
-        c.strokeStyle = this.border.color;
-        c.lineWidth = this.border.width;
-
-        if (!this.radius) {
-            c.fillRect(this.left, this.top, this.width, this.height);
-            c.strokeRect(this.left, this.top, this.width, this.height);
-        } else {
-            var r = this.left + this.width;
-            var b = this.top + this.height;
-            c.beginPath();
-            c.moveTo(this.left + this.radius, this.top);
-            c.lineTo(r - this.radius, this.top);
-            c.quadraticCurveTo(r, this.top, r, this.top + this.radius);
-            c.lineTo(r, this.top + this.height - this.radius);
-            c.quadraticCurveTo(r, b, r - this.radius, b);
-            c.lineTo(this.left + this.radius, b);
-            c.quadraticCurveTo(this.left, b, this.left, b - this.radius);
-            c.lineTo(this.left, this.top + this.radius);
-            c.quadraticCurveTo(this.left, this.top, this.left + this.radius, this.top);
-            c.stroke();
-            c.fill();
-        }
-        c.restore();
-    }
   }
 });

--- a/src/qtcore/qml/elements/QtQuick/Text.js
+++ b/src/qtcore/qml/elements/QtQuick/Text.js
@@ -13,24 +13,6 @@ registerQmlType({
     this.dom.firstChild.style.width = "100%";
     this.dom.firstChild.style.height = "100%";
 
-    // Creates font css description
-    function fontCss(font) {
-        var css = "";
-        css += font.italic ? "italic " : "normal ";
-        css += font.capitalization == "smallcaps" ? "small-caps " : "normal ";
-        // Canvas seems to only support bold yes or no
-        css += (font.weight == Font.Bold
-            || font.weight == Font.DemiBold
-            || font.weight == Font.Black
-            || font.bold) ? "bold " : "normal ";
-        css += font.pixelSize !== undefined
-            ? font.pixelSize + "px "
-            : (font.pointSize || 10) + "pt ";
-        css += this.lineHeight !== undefined ? this.lineHeight + "px " : " ";
-        css += (font.family || "sans-serif") + " ";
-        return css;
-    }
-
     this.Text = {
         // Wrap Mode
         NoWrap: 0,
@@ -180,16 +162,6 @@ registerQmlType({
             width = this.dom ? this.dom.firstChild.offsetWidth : 0;
 
         this.implicitWidth = width;
-    }
-
-    this.$drawItem = function(c) {
-        c.save();
-        c.font = fontCss(this.font);
-        c.fillStyle = this.color;
-        c.textAlign = "left";
-        c.textBaseline = "top";
-        c.fillText(this.text, this.left, this.top);
-        c.restore();
     }
   }
 });


### PR DESCRIPTION
This removes the remaining `.$draw()`, `.$drawItem()`, and `.$perfDraw()` methods.
Those were not used since the canvas renderer was removed.

/cc @Plaristote, @akreuzkamp.