### PR TITLE
fix js import test not passing

### DIFF
--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -460,7 +460,7 @@ QMLEngine = function (element, options) {
         if (name in this.components)
             return this.components[name];
 
-        var file = qmlEngine.$basePath + name + ".qml";
+        var file = engine.$basePath + name + ".qml";
 
         this.ensureFileIsLoadedInQrc(file);
         tree = convertToEngine(qrc[file]);

--- a/src/qtcore/qml/elements/Component.js
+++ b/src/qtcore/qml/elements/Component.js
@@ -54,8 +54,8 @@ function QMLComponent(meta) {
         var src = importDesc[1];
         var js;
 
-        if (typeof qmlEngine.$basePath != 'undefined')
-          src = qmlEngine.$basePath + src;
+        if (typeof engine.$basePath != 'undefined')
+          src = engine.$basePath + src;
         if (typeof qrc[src] != 'undefined')
           js = qrc[src];
         else

--- a/src/qtcore/qml/elements/Item.js
+++ b/src/qtcore/qml/elements/Item.js
@@ -104,7 +104,7 @@ function QMLItem(meta) {
         this.$context.activeFocus = this;
       } else if (document.qmlFocus == this) {
         document.getElementsByTagName("BODY")[0].focus();
-        document.qmlFocus = qmlEngine.rootContext().base;
+        document.qmlFocus = engine.rootContext().base;
         this.$context.activeFocus = null;
       }
     }).bind(this));

--- a/src/qtcore/qml/lib/jsparser.js
+++ b/src/qtcore/qml/lib/jsparser.js
@@ -12,10 +12,10 @@
   global.jsparse = function (source) {
     var obj = { exports: [], source: source };
     var AST_Tree = qmlweb_parse(source, qmlweb_parse.JSResource);
-    var foo_function_scope = AST_Tree[2][2][3];
+    var main_scope = AST_Tree[1];
 
-    for (var i = 0 ; i < foo_function_scope.length ; ++i) {
-      var item = foo_function_scope[i];
+    for (var i = 0 ; i < main_scope.length ; ++i) {
+      var item = main_scope[i];
 
       switch (item[0]) {
         case "var":

--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -6,7 +6,7 @@ describe('QMLEngine.imports', function() {
     load('Javascript', this.div);
     expect(this.div.offsetWidth).toBe(20);
     expect(this.div.offsetHeight).toBe(10);
-    expect(this.div.style.backgroundColor).toBe('magenta');
+    expect(this.div.style.backgroundColor).toBe('rgb(255, 0, 255)');
   });
   it('Qmldir', function() {
     load('Qmldir', this.div);

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -14,7 +14,6 @@ window.failingTests = {
       'can parse a function assigned to a var property'
     ],
     imports: [
-      'Javascript',
       'RecursiveInit',
       'RecursiveInit2'
     ],


### PR DESCRIPTION
* replace qmlEngine references with engine
* fix jsparser not properly walking the AST_Tree
* enable the QMLEngine JavascriptImport test

I noticed that js import wasn't working. Then I noticed the test was disabled. So I found what was blocking the test and fixed it (qmlEngine was used instead of engine in some place.... but qmlEngine is defined by the AutoLoader, and it's exclusively for use outside of qmlweb's scope. So I replaced the occurences of qmlEngine with engine).

Then I fixed a bug in jsparser, not properly using the AST_Tree returned by qmlparse.

The test was wrong as well: if we set a color to 'magenta', we shouldn't expect the CSS property to be 'magenta', but the rgb value for the magenta color (as this is the new behavior for QMLColor).