### PR TITLE
@igosoft merge: QMLPositioner: fix layoutChildren triggering

### DIFF
--- a/src/qtcore/qml/QMLPositioner.js
+++ b/src/qtcore/qml/QMLPositioner.js
@@ -17,10 +17,12 @@ QMLPositioner.slotChildrenChanged = function() {
             child.widthChanged.connect(this, this.layoutChildren);
         if (!child.heightChanged.isConnected(this, this.layoutChildren))
             child.heightChanged.connect(this, this.layoutChildren);
+        if (!child.implicitWidthChanged.isConnected(this, this.layoutChildren))
+            child.implicitWidthChanged.connect(this, this.layoutChildren);
+        if (!child.implicitHeightChanged.isConnected(this, this.layoutChildren))
+            child.implicitHeightChanged.connect(this, this.layoutChildren);
         if (!child.visibleChanged.isConnected(this, this.layoutChildren))
             child.visibleChanged.connect(this, this.layoutChildren);
-        if (!child.opacityChanged.isConnected(this, this.layoutChildren))
-            child.opacityChanged.connect(this, this.layoutChildren);
     }
 }
 


### PR DESCRIPTION
> QMLPositioner: fix layoutChildren triggering
> 
> In QML opacity doesn't change children layout.

Not sure about the additions here — do we need to update layout on implicit size changes?

/cc @igosoft @akreuzkamp @Plaristote

Ref: #128, #62.