### PR TITLE
Delay module registation until the base class is loaded.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var qtcoreSources = [
   'src/qtcore/qml/qml.js',
   'src/qtcore/qml/QMLBaseObject.js',
   'src/qtcore/qml/elements/Item.js',
-  'src/qtcore/qml/QMLPositioner.js',
+  'src/qtcore/qml/elements/QtQuick/Positioner.js',
   'src/qtcore/qml/elements/QtQuick/Repeater.js',
   'src/qtcore/qml/**/*.js'
 ];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,6 @@ var qtcoreSources = [
   'src/qtcore/qml/qml.js',
   'src/qtcore/qml/QMLBaseObject.js',
   'src/qtcore/qml/elements/Item.js',
-  'src/qtcore/qml/elements/QtQuick/Positioner.js',
-  'src/qtcore/qml/elements/QtQuick/Repeater.js',
   'src/qtcore/qml/**/*.js'
 ];
 

--- a/src/qtcore/qml/elements/QtQuick/Column.js
+++ b/src/qtcore/qml/elements/QtQuick/Column.js
@@ -22,6 +22,6 @@ registerQmlType({
   module: 'QtQuick',
   name:   'Column',
   versions: /.*/,
-  baseClass: QMLPositioner,
+  baseClass: 'Positioner',
   constructor: QMLColumn
 });

--- a/src/qtcore/qml/elements/QtQuick/Flow.js
+++ b/src/qtcore/qml/elements/QtQuick/Flow.js
@@ -61,6 +61,6 @@ registerQmlType({
   module:      'QtQuick',
   name:        'Flow',
   versions:    /.*/,
-  baseClass: QMLPositioner,
+  baseClass: 'Positioner',
   constructor: QMLFlow
 });

--- a/src/qtcore/qml/elements/QtQuick/Grid.js
+++ b/src/qtcore/qml/elements/QtQuick/Grid.js
@@ -2,7 +2,7 @@ registerQmlType({
   module: 'QtQuick',
   name: 'Grid',
   versions: /.*/,
-  baseClass: QMLPositioner,
+  baseClass: 'Positioner',
   constructor: QMLGrid
 });
 

--- a/src/qtcore/qml/elements/QtQuick/ListView.js
+++ b/src/qtcore/qml/elements/QtQuick/ListView.js
@@ -2,7 +2,7 @@ registerQmlType({
   module:   'QtQuick',
   name:     'ListView',
   versions: /.*/,
-  baseClass: QMLRepeater,
+  baseClass: 'Repeater',
   constructor: function QMLListView(meta) {
     var self = this;
     var QMLRepeater = getConstructor('QtQuick', '2.0', 'Repeater');

--- a/src/qtcore/qml/elements/QtQuick/Positioner.js
+++ b/src/qtcore/qml/elements/QtQuick/Positioner.js
@@ -8,7 +8,6 @@ function QMLPositioner(meta) {
 
     this.spacing = 0;
 }
-inherit(QMLPositioner, QMLItem);
 
 QMLPositioner.slotChildrenChanged = function() {
     for (var i = 0; i < this.children.length; i++) {
@@ -24,3 +23,10 @@ QMLPositioner.slotChildrenChanged = function() {
     }
 }
 
+registerQmlType({
+  module: 'QtQuick',
+  name:   'Positioner',
+  versions: /.*/,
+  baseClass: QMLItem,
+  constructor: QMLPositioner
+});

--- a/src/qtcore/qml/elements/QtQuick/Row.js
+++ b/src/qtcore/qml/elements/QtQuick/Row.js
@@ -2,7 +2,7 @@ registerQmlType({
   module:   'QtQuick',
   name:     'Row',
   versions: /.*/,
-  baseClass: QMLPositioner,
+  baseClass: 'Positioner',
   constructor: QMLRow
 });
 


### PR DESCRIPTION
Implement string-based baseClass specification.
This allows to delay module registration until the base class is loaded.

This fixes the issue discussed here: https://github.com/qmlweb/qmlweb/pull/160#issuecomment-206384442 in a sane way, without forcing us to manually specify the element order in the gulpfile.

It currently also supports a short syntax, i.e. `Repeater` instead of `QtQuick.Repeater` when used from `QtQuick` module. Is it worth it, or does that just overcomplicate things?

Not all modules were converted to the new syntax yet, only those ones that failed without it.

Also this PR adds QmlWeb.Basic module, which I propose would include supportive classes to implement QtQuick modules, but which should not be present in QtQuick itself.

This would also be required to split modules into separate files (one file per module), see https://github.com/qmlweb/qmlweb/issues/143#issuecomment-210131659. Cross-dependencies between modules would otherwise prevent that, and we have cross dependencies at least between QtQuick module and the helper classes that are not part of the module itself (moved to QmlWeb.Basic here).

/cc @Plaristote, @akreuzkamp. I would like to see your reviews here.