### PR TITLE
@pavelvasev merge: Aliases now emit changes signals

### DIFF
--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -31,6 +31,9 @@ QMLEngine = function (element, options) {
     // List of properties whose values are bindings. For internal use only.
     this.bindedProperties = [];
 
+    // List of operations to perform later after init. For internal use only.
+    this.pendingOperations = [];
+
     // Root object of the engine
     this.rootObject = null;
 
@@ -478,6 +481,17 @@ QMLEngine = function (element, options) {
             property.update();
         }
         this.bindedProperties = [];
+
+        this.$initializeAliasSignals();
+    }
+
+    this.$initializeAliasSignals = function() {
+        // Perform pending operations. Now we use it only to init alias's "changed" handlers, that's why we have such strange function name.
+        for (var i = 0; i < this.pendingOperations.length; i++) {
+            var op = this.pendingOperations[i];
+            op[0]( op[1] );
+        }
+        this.pendingOperations = [];
     }
 
     // Return a path to load the file

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -374,7 +374,26 @@ function applyProperties(metaObject, item, objectScope, componentScope) {
                       if (!targetProp) {
                         console.error("qtcore: target property [",prop.val.objectName,"].",prop.val.propertyName," not found for alias ",prop.name );
                       } else {
-                        targetProp.changed.connect( prop.changed );
+                        // targetProp.changed.connect( prop.changed );
+                        // it is not sufficient to connect to `changed` of source property
+                        // we have to propagate own changed to it too
+                        // seems the best way to do this is to make them identical?..
+                        // prop.changed = targetProp.changed;
+                        // obj[i + "Changed"] = prop.changed;
+                        // no. because those object might be destroyed later.
+                        ( function() {
+                          var loopWatchdog = false;
+                          targetProp.changed.connect( item, function() {
+                              if (loopWatchdog) return; loopWatchdog = true;
+                              prop.changed.apply( item,arguments );
+                              loopWatchdog = false;
+                          } );
+                          prop.changed.connect( obj, function() {
+                              if (loopWatchdog) return; loopWatchdog = true;
+                              targetProp.changed.apply( obj, arguments );
+                              loopWatchdog = false;
+                          } );
+                        } ) ();
                       }
                     }
                   }

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -18,7 +18,6 @@ window.failingTests = {
       'RecursiveInit2'
     ],
     properties: [
-      'alias have changed signal',
       'alias propagates it\'s changed signal back to referenced property',
       'alias to id with same name',
       'ChangedExpressionSignal',

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -18,7 +18,6 @@ window.failingTests = {
       'RecursiveInit2'
     ],
     properties: [
-      'alias propagates it\'s changed signal back to referenced property',
       'alias to id with same name',
       'ChangedExpressionSignal',
       'StringConversion',


### PR DESCRIPTION
This merges 780450b635332ebd5182526b0123ad297c50fff1 and the aliases part of dce7d96.

Note: I have not reviewed this code.
Note: This fixes two testcases. It also blocks sorting out the two remaining changestets of #32, so it would be better to review this quickly =).

Ref: #32.

/cc @pavelvasev @Plaristote @akreuzkamp 