### PR TITLE
@pavelvasev merge: QObject: Add .destroy() method

### DIFF
--- a/src/qtcore/qml/QObject.js
+++ b/src/qtcore/qml/QObject.js
@@ -35,4 +35,8 @@ function QObject(parent) {
         // 2) DOM node will be removed.
         this.parent = undefined;
     }
+
+    // must have `destroy` method
+    // http://doc.qt.io/qt-5/qtqml-javascript-dynamicobjectcreation.html
+    this.destroy = this.$delete;
 }


### PR DESCRIPTION
Extracted from 4c3bcc649447c07401a53677b801c937d03779bb.

Note: I have not reviewed this code.
Note: `.destroy()` is used in RestModel for some reason.

Ref: #32.

/cc @pavelvasev @Plaristote @akreuzkamp 