### PR TITLE
@pavelvasev merge: CheckBox: fix implicitWidth

### DIFF
--- a/src/modules/QtQuick.Controls/Checkbox.js
+++ b/src/modules/QtQuick.Controls/Checkbox.js
@@ -21,12 +21,12 @@ registerQmlType({
 
     this.Component.completed.connect(this, function() {
         this.implicitHeight = this.dom.offsetHeight;
-        this.implicitWidth = this.dom.offsetWidth;
+        this.implicitWidth = this.dom.offsetWidth > 0 ? this.dom.offsetWidth + 4 : 0;
     });
     this.textChanged.connect(this, function(newVal) {
         this.dom.children[1].innerHTML = newVal;
         this.implicitHeight = this.dom.offsetHeight;
-        this.implicitWidth = this.dom.offsetWidth;
+        this.implicitWidth = this.dom.offsetWidth > 0 ? this.dom.offsetWidth + 4 : 0;
     });
     this.colorChanged.connect(this, function(newVal) {
         this.dom.children[1].style.color = QMLColor(newVal);


### PR DESCRIPTION
This merges 6bbfa8301bfc06c5f29c5da6bd116df2300b62c9.

Ref: #32.

@pavelvasev, could you explain why this is needed and why is a value of 4 pixels hardcoded?

/cc @pavelvasev @Plaristote @akreuzkamp 