### PR TITLE
@pavelvasev merge: Root element resizing fixes

### DIFF
--- a/src/modules/QtQuick/Item.js
+++ b/src/modules/QtQuick/Item.js
@@ -347,14 +347,30 @@ function QMLItem(meta) {
     // Init size of root element
     if (this.$parent === null) {
         if (engine.rootElement == undefined) {
-            window.onresize = function() {
+            // Case 1: Qml scene is placed in body tag
+
+            // event handling by addEventListener is probably better than setting window.onresize
+            var updateQmlGeometry = function() {
                 self.implicitHeight = window.innerHeight;
                 self.implicitWidth = window.innerWidth;
             }
-            window.onresize();
+            window.addEventListener( "resize", updateQmlGeometry );
+            updateQmlGeometry();
         } else {
-            this.implicitHeight = this.dom.offsetHeight;
-            this.implicitWidth = this.dom.offsetWidth;
+            // Case 2: Qml scene is placed in some element tag
+
+            // we have to call `self.implicitHeight =` and `self.implicitWidth =`
+            // each time the rootElement changes it's geometry
+            // to reposition child elements of qml scene
+
+            // it is good to have this as named method of dom element, so we can call it
+            // from outside too, whenever element changes it's geometry (not only on window resize)
+            this.dom.updateQmlGeometry = function() {
+              self.implicitHeight = self.dom.offsetHeight;
+              self.implicitWidth = self.dom.offsetWidth;
+            };
+            window.addEventListener( "resize", this.dom.updateQmlGeometry );
+            this.dom.updateQmlGeometry();
         }
     }
 }


### PR DESCRIPTION
This is a cherry-pick of a339ee7, ref: #32.

Commit message:

> Root element resizing fixes
> 
> 1. window.onresize function is changed to addEventListener("resize")
call.
2. In case when qml scene is placed in some dom tag (case 2),
we have to call `self.implicitHeight =` and `self.implicitWidth =`
each time the rootElement changes it's geometry
to reposition child elements of qml scene

> Also there is a small note. Because in qmlweb implicitHeight= is chained
to updateHGeometry,
which in turn calls height=, which in turn sets element dom style, the
user have to set
rootElement's width/height css styles to !important.
Maybe it should be noted somewhere in the docs. This note is not
regarding to the current patch.

@pavelvasev What is the reason for storing the callback in `this.dom.updateQmlGeometry` in one case and not storing in the the other case? Why not add save the callback as `this.dom.updateQmlGeometry` for all cases?