### PR TITLE
AnimatedImage: fix a mistype in constructor

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/AnimatedImage.js
+++ b/src/qtcore/qml/elements/QtQuick/AnimatedImage.js
@@ -3,7 +3,7 @@ registerQmlType({
   name:     'AnimatedImage',
   versions: /.*/,
   baseClass: QMLImage,
-  constructors: function QMLAnimatedImage(meta) {
+  constructor: function QMLAnimatedImage(meta) {
     QMLImage.call(this, meta);
   }
 });


### PR DESCRIPTION
This is trivial, hoping for a quick review here.

This does not fix the `AnimatedImage` testcase just yet,  #200 (with more fixes) is required for that.