### PR TITLE
Remove outer eval in jsparser. Babelify everything but parser.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": ["es2015"],
   "ignore": [
-    "src/qtcore/qml/qt.js",
     "src/qtcore/qml/lib/parser.js"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "presets": ["es2015"],
   "ignore": [
     "src/qtcore/qml/qt.js",
-    "src/qtcore/qml/lib/parser.js",
-    "src/qtcore/qml/lib/jsparser.js"
+    "src/qtcore/qml/lib/parser.js"
   ]
 }

--- a/src/qtcore/qml/lib/jsparser.js
+++ b/src/qtcore/qml/lib/jsparser.js
@@ -1,4 +1,3 @@
-(function() {
   global.importJavascriptInContext = function (jsData, $context) {
     // TODO: pass more objects to the scope?
     (new Function('jsData', '$context', `
@@ -31,5 +30,3 @@
     }
     return obj;
   }
-
-})();

--- a/src/qtcore/qml/lib/jsparser.js
+++ b/src/qtcore/qml/lib/jsparser.js
@@ -1,12 +1,15 @@
 (function() {
   global.importJavascriptInContext = function (jsData, $context) {
-    with($context) {
-      eval(jsData.source);
+    // TODO: pass more objects to the scope?
+    (new Function('jsData', '$context', `
+      with ($context) {
+        ${jsData.source}
+      }
       for (var i = 0 ; i < jsData.exports.length ; ++i) {
         var symbolName = jsData.exports[i];
         $context[symbolName] = eval(symbolName);
       }
-    }
+    `))(jsData, $context);
   }
 
   global.jsparse = function (source) {

--- a/src/qtcore/qt.js
+++ b/src/qtcore/qt.js
@@ -222,7 +222,6 @@ global.Qt = {
   Key_VolumeDown: 182,
   Key_VolumeUp: 183,
   Key_VolumeMute: 181,
-  Key_Yes: 0,
   Key_multiply: 106,
   Key_add: 107,
   Key_substract: 109,


### PR DESCRIPTION
The main change here is 00db7e0ede1ac09a796a7ca60904ae56287b8f55, the other two are minor fixes.

`Qt.Key_Yes` was defined twice, I removed a duplicate.

/cc @Plaristote 