### PR TITLE
parser: Move QML runtime elements to qmlstructure.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var karma = require('karma');
 var qtcoreSources = [
   'src/qtcore/qml/QMLBinding.js',
   'src/qtcore/qml/lib/parser.js',
+  'src/qtcore/qml/lib/qmlstructure.js',
   'src/qtcore/qml/lib/import.js',
   'src/qtcore/*.js',
   'src/qtcore/qml/qml.js',

--- a/src/qtcore/qml/lib/parser.js
+++ b/src/qtcore/qml/lib/parser.js
@@ -53,13 +53,8 @@
  *
  * Exports:
  *
- * - QMLBinding(src, tree) to pass qml bindings along.
- *
  * - parseQML(src) -- parses QML source and returns it as output tree expected
  *   by the QML engine
- *
- * - qmlweb_parse(src) -- parses QML or JS source and returns tree a la uglifyjs parser.
- *   Currently used for debugging purposes.
  */
 
 // Object cloning for debug prints.
@@ -276,7 +271,7 @@ function QMLParseError(message, line, col, pos, comment) {
         this.pos = pos;
         this.comment = comment ? comment : "";
         this.message = message + " (line: " + line + ", col: " + col + ", pos: " + pos + ")" + "\n" + comment + "\n"
-        this.file = nowParsingFile;
+        this.file = qmlweb_parse.nowParsingFile;
         try {
                 ({})();
         } catch(ex) {
@@ -696,6 +691,7 @@ function NodeWithToken(str, start, end) {
 
 NodeWithToken.prototype.toString = function() { return this.name; };
 
+qmlweb_parse.nowParsingFile = ''; // TODO: make a parameter of qmlweb_parse
 qmlweb_parse.QMLDocument = 1;
 qmlweb_parse.JSResource = 2;
 function qmlweb_parse($TEXT, document_type, exigent_mode, embed_tokens) {
@@ -1562,220 +1558,6 @@ function HOP(obj, prop) {
 };
 
 var warn = function() {};
-
-QMLMethod.prototype = new QMLBinding();
-function QMLMethod(src) {
-    this.src = src;
-}
-
-/**
- * Create an object representing a QML property definition.
- * @param {String} type The type of the property
- * @param {Array} value The default value of the property
- * @return {Object} Object representing the defintion
- */
-function QMLPropertyDefinition(type, value) {
-    this.type = type;
-    this.value = value;
-}
-
-function QMLAliasDefinition(objName, propName) {
-    this.objectName = objName;
-    this.propertyName = propName;
-}
-
-/**
- * Create an object representing a QML signal definition.
- * @param {Array} params The parameters the signal ships
- * @return {Object} Object representing the defintion
- */
-function QMLSignalDefinition(params) {
-    this.parameters = params;
-}
-
-/**
- * Create an object representing a group of QML properties (like anchors).
- * @return {Object} Object representing the group
- */
-function QMLMetaPropertyGroup() {}
-
-/**
- * Create an object representing a QML element.
- * @param {String} type The type of the element
- * @param {String} onProp The name of the property specified with the "on" keyword
- */
-function QMLMetaElement(type, onProp) {
-    this.$class = type;
-    this.$children = [];
-    this.$on = onProp;
-}
-
-// Convert parser tree to the format understood by engine
-function convertToEngine(tree) {
-
-    // Help logger
-    function amIn(str, tree) {
-        console.log(str);
-        if (tree) console.log(JSON.stringify(tree, null, "  "));
-    }
-
-    var walkers = {
-        "toplevel": function(imports, statement) {
-            var item = { $class: "QMLDocument" };
-            item.$imports = imports;
-            item.$children = [ walk(statement) ];
-            return item;
-        },
-        "qmlelem": function(elem, onProp, statements) {
-            var item = new QMLMetaElement(elem, onProp);
-
-            for (var i in statements) {
-                var statement = statements[i],
-                    name = statement[1],
-                    val = walk(statement);
-                switch (statement[0]) {
-                    case "qmldefaultprop":
-                        item.$defaultProperty = name;
-                    case "qmlprop":
-                    case "qmlpropdef":
-                    case "qmlaliasdef":
-                    case "qmlmethod":
-                    case "qmlsignaldef":
-                        item[name] = val;
-                        break;
-                    case "qmlelem":
-                        item.$children.push(val);
-                        break;
-                    case "qmlobjdef":
-                        // Create object to item
-                        item[name] = item[name] || new QMLMetaPropertyGroup();
-                        item[name][statement[2]] = val;
-                        break;
-                    case "qmlobj":
-                        // Create object to item
-                        item[name] = item[name] || new QMLMetaPropertyGroup();
-                        for (var i in val)
-                            item[name][i] = val[i];
-                        break;
-                    default:
-                        console.log("Unknown statement", statement);
-
-                }
-            }
-            // Make $children be either a single item or an array, if it's more than one
-            if (item.$children.length === 1)
-                item.$children = item.$children[0];
-
-            return item;
-        },
-        "qmlprop": function(name, tree, src) {
-            if (name == "id") {
-                // id property
-                return tree[1][1];
-            }
-            return bindout(tree, src);
-        },
-        "qmlobjdef": function(name, property, tree, src) {
-            return bindout(tree, src);
-        },
-        "qmlobj": function(elem, statements) {
-            var item = {};
-
-            for (var i in statements) {
-                var statement = statements[i],
-                    name = statement[1],
-                    val = walk(statement);
-                if (statement[0] == "qmlprop")
-                    item[name] = val;
-            }
-
-            return item;
-        },
-        "qmlmethod": function(name, tree, src) {
-            return new QMLMethod(src);
-        },
-        "qmlpropdef": function(name, type, tree, src) {
-            return new QMLPropertyDefinition(type, tree ? bindout(tree, src) : "");
-        },
-        "qmlaliasdef": function(name, objName, propName) {
-            return new QMLAliasDefinition(objName, propName);
-        },
-        "qmlsignaldef": function(name, params) {
-            return new QMLSignalDefinition(params);
-        },
-        "qmldefaultprop": function(tree) {
-            return walk(tree);
-        },
-        "name": function(src) {
-            if (src == "true" || src == "false")
-                return src == "true";
-            return new QMLBinding(src, ["name", src]);
-        },
-        "num": function(src) {
-            return +src;
-        },
-        "string": function(src) {
-            return String(src);
-        },
-        "array": function(tree, src) {
-            var a = [];
-            var isList = false;
-            var hasBinding = false;
-            for (var i in tree) {
-                var val = bindout(tree[i]);
-                a.push(val);
-
-                if (val instanceof QMLMetaElement)
-                    isList = true;
-                else if (val instanceof QMLBinding)
-                    hasBinding = true;
-            }
-
-            if (hasBinding) {
-                if (isList)
-                    throw new TypeError("An array may either contain bindings or Element definitions.");
-                return new QMLBinding(src, tree);
-            }
-
-            return a;
-        }
-    };
-
-    function walk(tree) {
-        var type = tree[0];
-        var walker = walkers[type];
-        if (!walker) {
-            console.log("No walker for " + type);
-            return;
-        } else {
-            return walker.apply(type, tree.slice(1));
-        }
-    }
-
-    return walk(tree);
-
-    // Try to bind out tree and return static variable instead of binding
-    function bindout(tree, binding) {
-        if (tree[0] === "stat") // We want to process the content of the statement
-            tree = tree[1];     // (but still handle the case, we get the content directly)
-        var type = tree[0];
-        var walker = walkers[type];
-        if (walker) {
-            return walker.apply(type, tree.slice(1));
-        } else {
-            return new QMLBinding(binding, tree);
-        }
-    }
-
-}
-
-// Function to parse qml and output tree expected by engine
-var nowParsingFile = "";
-function parseQML(src, file) {
-    nowParsingFile = file;
-    var parsetree = qmlweb_parse(src, qmlweb_parse.QmlDocument);
-    return convertToEngine(parsetree);
-}
 
 if (typeof global != "undefined") {
   global.qmlweb_parse = qmlweb_parse;

--- a/src/qtcore/qml/lib/qmlstructure.js
+++ b/src/qtcore/qml/lib/qmlstructure.js
@@ -1,0 +1,244 @@
+/* @license
+
+  Copyright (c) 2011 Lauri Paimen <lauri@paimen.info>
+  Copyright (c) 2013 Anton Kreuzkamp <akreuzkamp@web.de>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+      * Redistributions of source code must retain the above
+        copyright notice, this list of conditions and the following
+        disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.
+*/
+
+QMLMethod.prototype = new QMLBinding();
+function QMLMethod(src) {
+    this.src = src;
+}
+
+/**
+ * Create an object representing a QML property definition.
+ * @param {String} type The type of the property
+ * @param {Array} value The default value of the property
+ * @return {Object} Object representing the defintion
+ */
+function QMLPropertyDefinition(type, value) {
+    this.type = type;
+    this.value = value;
+}
+
+function QMLAliasDefinition(objName, propName) {
+    this.objectName = objName;
+    this.propertyName = propName;
+}
+
+/**
+ * Create an object representing a QML signal definition.
+ * @param {Array} params The parameters the signal ships
+ * @return {Object} Object representing the defintion
+ */
+function QMLSignalDefinition(params) {
+    this.parameters = params;
+}
+
+/**
+ * Create an object representing a group of QML properties (like anchors).
+ * @return {Object} Object representing the group
+ */
+function QMLMetaPropertyGroup() {}
+
+/**
+ * Create an object representing a QML element.
+ * @param {String} type The type of the element
+ * @param {String} onProp The name of the property specified with the "on" keyword
+ */
+function QMLMetaElement(type, onProp) {
+    this.$class = type;
+    this.$children = [];
+    this.$on = onProp;
+}
+
+// Convert parser tree to the format understood by engine
+function convertToEngine(tree) {
+
+    // Help logger
+    function amIn(str, tree) {
+        console.log(str);
+        if (tree) console.log(JSON.stringify(tree, null, "  "));
+    }
+
+    var walkers = {
+        "toplevel": function(imports, statement) {
+            var item = { $class: "QMLDocument" };
+            item.$imports = imports;
+            item.$children = [ walk(statement) ];
+            return item;
+        },
+        "qmlelem": function(elem, onProp, statements) {
+            var item = new QMLMetaElement(elem, onProp);
+
+            for (var i in statements) {
+                var statement = statements[i],
+                    name = statement[1],
+                    val = walk(statement);
+                switch (statement[0]) {
+                    case "qmldefaultprop":
+                        item.$defaultProperty = name;
+                    case "qmlprop":
+                    case "qmlpropdef":
+                    case "qmlaliasdef":
+                    case "qmlmethod":
+                    case "qmlsignaldef":
+                        item[name] = val;
+                        break;
+                    case "qmlelem":
+                        item.$children.push(val);
+                        break;
+                    case "qmlobjdef":
+                        // Create object to item
+                        item[name] = item[name] || new QMLMetaPropertyGroup();
+                        item[name][statement[2]] = val;
+                        break;
+                    case "qmlobj":
+                        // Create object to item
+                        item[name] = item[name] || new QMLMetaPropertyGroup();
+                        for (var i in val)
+                            item[name][i] = val[i];
+                        break;
+                    default:
+                        console.log("Unknown statement", statement);
+
+                }
+            }
+            // Make $children be either a single item or an array, if it's more than one
+            if (item.$children.length === 1)
+                item.$children = item.$children[0];
+
+            return item;
+        },
+        "qmlprop": function(name, tree, src) {
+            if (name == "id") {
+                // id property
+                return tree[1][1];
+            }
+            return bindout(tree, src);
+        },
+        "qmlobjdef": function(name, property, tree, src) {
+            return bindout(tree, src);
+        },
+        "qmlobj": function(elem, statements) {
+            var item = {};
+
+            for (var i in statements) {
+                var statement = statements[i],
+                    name = statement[1],
+                    val = walk(statement);
+                if (statement[0] == "qmlprop")
+                    item[name] = val;
+            }
+
+            return item;
+        },
+        "qmlmethod": function(name, tree, src) {
+            return new QMLMethod(src);
+        },
+        "qmlpropdef": function(name, type, tree, src) {
+            return new QMLPropertyDefinition(type, tree ? bindout(tree, src) : "");
+        },
+        "qmlaliasdef": function(name, objName, propName) {
+            return new QMLAliasDefinition(objName, propName);
+        },
+        "qmlsignaldef": function(name, params) {
+            return new QMLSignalDefinition(params);
+        },
+        "qmldefaultprop": function(tree) {
+            return walk(tree);
+        },
+        "name": function(src) {
+            if (src == "true" || src == "false")
+                return src == "true";
+            return new QMLBinding(src, ["name", src]);
+        },
+        "num": function(src) {
+            return +src;
+        },
+        "string": function(src) {
+            return String(src);
+        },
+        "array": function(tree, src) {
+            var a = [];
+            var isList = false;
+            var hasBinding = false;
+            for (var i in tree) {
+                var val = bindout(tree[i]);
+                a.push(val);
+
+                if (val instanceof QMLMetaElement)
+                    isList = true;
+                else if (val instanceof QMLBinding)
+                    hasBinding = true;
+            }
+
+            if (hasBinding) {
+                if (isList)
+                    throw new TypeError("An array may either contain bindings or Element definitions.");
+                return new QMLBinding(src, tree);
+            }
+
+            return a;
+        }
+    };
+
+    function walk(tree) {
+        var type = tree[0];
+        var walker = walkers[type];
+        if (!walker) {
+            console.log("No walker for " + type);
+            return;
+        } else {
+            return walker.apply(type, tree.slice(1));
+        }
+    }
+
+    return walk(tree);
+
+    // Try to bind out tree and return static variable instead of binding
+    function bindout(tree, binding) {
+        if (tree[0] === "stat") // We want to process the content of the statement
+            tree = tree[1];     // (but still handle the case, we get the content directly)
+        var type = tree[0];
+        var walker = walkers[type];
+        if (walker) {
+            return walker.apply(type, tree.slice(1));
+        } else {
+            return new QMLBinding(binding, tree);
+        }
+    }
+
+}
+
+// Function to parse qml and output tree expected by engine
+function parseQML(src, file) {
+    qmlweb_parse.nowParsingFile = file;
+    var parsetree = qmlweb_parse(src, qmlweb_parse.QmlDocument);
+    return convertToEngine(parsetree);
+}


### PR DESCRIPTION
This is the first step towards #173.

Basicaly, `parser.js` now exports only `qmlweb_parse`, everything else is internal.

Elements from `qmlstructure.js` and `QMLBinding` would be needed at runtime, `qmlweb_parse` (and everything else from `parser.js`) won't be, if the user would use pre-parsed files.

In future, everything but `parser.js` would be kept in the main repo, `parser.js` would be made a stand-alone library and an optional requirement (auto-loaded, though).

/cc @Plaristote, @akreuzkamp, @lpaimen.

@akreuzkamp, @lpaimen — could you confirm that I got the copyrights correct? There seems to be no code from UglifyJS in the new `qmlstructure.js`, please correct me if I'm wrong.