### PR TITLE
@igosoft merge: Do not hide zero-opacity items in positioners

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/Column.js
+++ b/src/qtcore/qml/elements/QtQuick/Column.js
@@ -7,7 +7,7 @@ QMLColumn.prototype.layoutChildren = function() {
         maxWidth = 0;
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i];
-        if (!(child.visible && child.opacity && child.width && child.height))
+        if (!(child.visible && child.width && child.height))
             continue;
         maxWidth = child.width > maxWidth ? child.width : maxWidth;
 

--- a/src/qtcore/qml/elements/QtQuick/Flow.js
+++ b/src/qtcore/qml/elements/QtQuick/Flow.js
@@ -22,7 +22,7 @@ QMLFlow.prototype.layoutChildren = function() {
         rowSize = 0;
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i];
-        if (!(child.visible && child.opacity && child.width && child.height))
+        if (!(child.visible && child.width && child.height))
             continue;
 
         if (this.flow == this.Flow.LeftToRight) {

--- a/src/qtcore/qml/elements/QtQuick/Grid.js
+++ b/src/qtcore/qml/elements/QtQuick/Grid.js
@@ -40,7 +40,7 @@ QMLGrid.prototype.layoutChildren = function() {
     // How many items are actually visible?
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i];
-        if (child.visible && child.opacity && child.width && child.height)
+        if (child.visible && child.width && child.height)
             visibleItems.push(this.children[i]);
     }
 

--- a/src/qtcore/qml/elements/QtQuick/Positioner.js
+++ b/src/qtcore/qml/elements/QtQuick/Positioner.js
@@ -18,8 +18,6 @@ QMLPositioner.slotChildrenChanged = function() {
             child.heightChanged.connect(this, this.layoutChildren);
         if (!child.visibleChanged.isConnected(this, this.layoutChildren))
             child.visibleChanged.connect(this, this.layoutChildren);
-        if (!child.opacityChanged.isConnected(this, this.layoutChildren))
-            child.opacityChanged.connect(this, this.layoutChildren);
     }
 }
 

--- a/src/qtcore/qml/elements/QtQuick/Row.js
+++ b/src/qtcore/qml/elements/QtQuick/Row.js
@@ -23,7 +23,7 @@ QMLRow.prototype.layoutChildren = function() {
         step = this.layoutDirection == 1 ? -1 : 1;
     for (; i !== endPoint; i += step) {
         var child = this.children[i];
-        if (!(child.visible && child.opacity && child.width && child.height))
+        if (!(child.visible && child.width && child.height))
             continue;
         maxHeight = child.height > maxHeight ? child.height : maxHeight;
 

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -5,8 +5,7 @@ window.failingTests = {
     ],
     Simple: [
       'RectangleBorderChildren',
-      'RectanglesOpacity',
-      'ZeroOpacityLayout'
+      'RectanglesOpacity'
     ]
   },
   QMLEngine: {


### PR DESCRIPTION
This fixes the zero opacity testcase mentioned in #185 and #191.

Merges 3b78802 and d53fefb.

Refs: #128.

LGTM.

/cc @igosoft, @Plaristote, @akreuzkamp 