### PR TITLE
@igosoft merge: QMLEngine: return root component from load{File,QML,QMLTree}

### DIFF
--- a/src/qtcore/qml/QMLEngine.js
+++ b/src/qtcore/qml/QMLEngine.js
@@ -97,12 +97,12 @@ QMLEngine = function (element, options) {
         this.$basePath = this.extractBasePath(file);
         this.ensureFileIsLoadedInQrc(file);
         tree = convertToEngine(qrc[file]);
-        this.loadQMLTree(tree, parentComponent, file);
+        return this.loadQMLTree(tree, parentComponent, file);
     }
 
     // parse and construct qml
     this.loadQML = function(src, parentComponent = null, file = undefined) { // file is not required; only for debug purposes
-        this.loadQMLTree(parseQML(src, file), parentComponent, file);
+        return this.loadQMLTree(parseQML(src, file), parentComponent, file);
     }
 
     this.loadQMLTree = function(tree, parentComponent = null, file = undefined) {
@@ -126,6 +126,8 @@ QMLEngine = function (element, options) {
         this.start();
 
         this.callCompletedSignals();
+
+        return component;
     }
 
     /** from http://docs.closure-library.googlecode.com/git/local_closure_goog_uri_uri.js.source.html


### PR DESCRIPTION
It seems that nothing does use this in @igosoft fork, so I am not sure if we need this.

~~Based on #193, review only the last commit here.~~ *Update: rebased on master instead*.

This is a cherry-pick of a6618d4bb56ffb97a75d12c02fc5cdea91e2bda6 with `loadQML` support added for consistency.

/cc @igosoft @Plaristote @akreuzkamp @pavelvasev

Refs: #128.