### PR TITLE
@igosoft merge: Do not return values from property setters

### DIFF
--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -229,12 +229,12 @@ function createSimpleProperty(type, obj, propName, options) {
     obj.$properties[propName].set(options.default);
     getter = function()       { return obj.$properties[propName].get(); };
     if (!options.readOnly)
-      setter = function(newVal) { return obj.$properties[propName].set(newVal, QMLProperty.ReasonUser); };
+      setter = function(newVal) { obj.$properties[propName].set(newVal, QMLProperty.ReasonUser); };
     else {
       setter = function(newVal) {
         if (obj.$canEditReadOnlyProperties != true)
           throw "property '" + propName + "' has read only access";
-        return obj.$properties[propName].set(newVal, QMLProperty.ReasonUser);
+        obj.$properties[propName].set(newVal, QMLProperty.ReasonUser);
       }
     }
     setupGetterSetter(obj, propName, getter, setter);


### PR DESCRIPTION
There is no need to return things from setters, those are not used — `a = b` always returns `b` (i.e. the value being assigned), returning anything from the setter does not affect that.

This merges abdc0e0adfd6529c6f6989a1a780845bfb628393, ref: #128.

LGTM, going to merge shortly.