### PR TITLE
@igosoft merge: Do not perform layoutChildren for empty positioners

### DIFF
--- a/src/qtcore/qml/elements/QtQuick/Column.js
+++ b/src/qtcore/qml/elements/QtQuick/Column.js
@@ -5,6 +5,7 @@ function QMLColumn(meta) {
 QMLColumn.prototype.layoutChildren = function() {
     var curPos = 0,
         maxWidth = 0;
+    if (this.children.length === 0) return;
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i];
         if (!(child.visible && child.width && child.height))

--- a/src/qtcore/qml/elements/QtQuick/Flow.js
+++ b/src/qtcore/qml/elements/QtQuick/Flow.js
@@ -20,6 +20,9 @@ QMLFlow.prototype.layoutChildren = function() {
     var curHPos = 0,
         curVPos = 0,
         rowSize = 0;
+
+    if (children.length == 0) return;
+
     for (var i = 0; i < this.children.length; i++) {
         var child = this.children[i];
         if (!(child.visible && child.width && child.height))

--- a/src/qtcore/qml/elements/QtQuick/Row.js
+++ b/src/qtcore/qml/elements/QtQuick/Row.js
@@ -21,6 +21,9 @@ QMLRow.prototype.layoutChildren = function() {
         i = this.layoutDirection == 1 ? this.children.length - 1 : 0,
         endPoint = this.layoutDirection == 1 ? -1 : this.children.length,
         step = this.layoutDirection == 1 ? -1 : 1;
+
+    if (this.children.length == 0) return;
+
     for (; i !== endPoint; i += step) {
         var child = this.children[i];
         if (!(child.visible && child.width && child.height))


### PR DESCRIPTION
This merges 73c6e57, ref: #128.

I am not conviced with this patch. Removing the children should update implicit size, and with this PR that would not happen, as it seems to me.

/cc @igosoft 