### PR TITLE
jsparser: Replace eval with codegen

### DIFF
--- a/src/qtcore/qml/lib/jsparser.js
+++ b/src/qtcore/qml/lib/jsparser.js
@@ -4,10 +4,7 @@
       with ($context) {
         ${jsData.source}
       }
-      for (var i = 0 ; i < jsData.exports.length ; ++i) {
-        var symbolName = jsData.exports[i];
-        $context[symbolName] = eval(symbolName);
-      }
+      ${jsData.exports.map(sym => `$context.${sym} = ${sym};`).join('')}
     `))(jsData, $context);
   }
 


### PR DESCRIPTION
This is a follow-up to #214 that removes the remaining `eval()` and replaces it with code generation.

No more evals in code :wink:.

/cc @Plaristote 