### PR TITLE
Fix Behavior

### DIFF
--- a/src/qtcore/qml/QMLProperty.js
+++ b/src/qtcore/qml/QMLProperty.js
@@ -87,7 +87,7 @@ QMLProperty.prototype.set = function(newVal, reason, objectScope, componentScope
             return;
         }
     } else {
-        if (!reason != QMLProperty.ReasonAnimation)
+        if (reason != QMLProperty.ReasonAnimation)
             this.binding = null;
         if (newVal instanceof Array)
             newVal = newVal.slice(); // Copies the array


### PR DESCRIPTION
This was broken when translation from "!fromAnimation" to using
QMLPropery.ReasonAnimation in 8c5d600d109be4c2bf7373e8e6e5f78d9b996b1d.

Without this change, attaching a Behavior to a property will result in the binding being removed.