### PR TITLE
Per import context constructors

### DIFF
--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -434,6 +434,7 @@ class QMLEngine {
     const file = `${this.$basePath}${name}.qml`;
     this.ensureFileIsLoadedInQrc(file);
     const tree = QmlWeb.convertToEngine(QmlWeb.qrc[file]);
+    tree.$file = file;
     this.components[name] = tree;
     return tree;
   }

--- a/src/engine/QMLProperty.js
+++ b/src/engine/QMLProperty.js
@@ -144,6 +144,11 @@ class QMLProperty {
           parent: this.obj,
           context: componentScope
         });
+        /* $basePath must be set here so that Components that are assigned to
+         * properties (e.g. Repeater delegates) can properly resolve child
+         * Components that live in the same directory in
+         * Component.createObject. */
+        this.val.$basePath = componentScope.$basePath;
       } else {
         this.val = QmlWeb.construct({
           object: val,

--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -261,14 +261,23 @@ function construct(meta) {
             // We have that component in some qmldir, load it from qmldir's url
             component = Qt.createComponent( "@" + qdirInfo.url);
         }
-        else
-            component = Qt.createComponent(meta.object.$class + ".qml");
+        else {
+            var filePath;
+            if (classComponents.length === 2) {
+                filePath = QmlWeb.engine.qualifiedImportPath(
+                    meta.context.importContextId, classComponents[0]) +
+                        classComponents[1];
+            } else {
+                filePath = classComponents[0];
+            }
+            component = Qt.createComponent(filePath + ".qml");
+        }
 
         if (component) {
             var item = component.$createObject(meta.parent);
 
             if (typeof item.dom != 'undefined')
-                item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");
+                item.dom.className += " " + classComponents[classComponents.length-1] + (meta.object.id ? " " + meta.object.id : "");
             var dProp; // Handle default properties
         } else {
             throw new Error("No constructor found for " + meta.object.$class);

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -38,6 +38,13 @@ class QMLComponent {
         this.finalizeImports(this.$context);
       }
     }
+
+    /* If this Component does not have any imports, it is likely one that was
+     * created within another Component file. It should inherit the
+     * importContextId of the Component file it was created within. */
+    if (this.importContextId === undefined) {
+      this.importContextId = meta.context.importContextId;
+    }
   }
   finalizeImports($context) {
     for (let i = 0; i < this.$jsImports.length; ++i) {

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -62,7 +62,7 @@ class QMLComponent {
       }
     }
   }
-  $createObject(parent, properties = {}) {
+  $createObject(parent, properties = {}, context = this.$context) {
     const engine = QmlWeb.engine;
     const oldState = engine.operationState;
     engine.operationState = QmlWeb.QMLOperationState.Init;
@@ -70,10 +70,16 @@ class QMLComponent {
     const bp = engine.$basePath;
     engine.$basePath = this.$basePath ? this.$basePath : engine.$basePath;
 
+    const newContext = context ? Object.create(context) : new QMLContext();
+
+    if (this.importContextId !== undefined) {
+      newContext.importContextId = this.importContextId;
+    }
+
     const item = QmlWeb.construct({
       object: this.$metaObject,
       parent,
-      context: this.$context ? Object.create(this.$context) : new QMLContext(),
+      context: newContext,
       isComponentRoot: true
     });
 

--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -23,7 +23,7 @@ const Qt = {
     }
 
     // e.g. // in protocol, or :/ in disk urls (D:/)
-    let nameIsUrl = name.indexOf("//") >= 0 || name.indexOf(":/") >= 0;
+    let nameIsUrl = name.indexOf("//") === 0 || name.indexOf(":/") >= 0;
 
     let resolvedName;
     if (name.length > 0 && name[0] === "@") {
@@ -42,7 +42,8 @@ const Qt = {
     // if failed to load, and provided name is not direct url,
     // try to load from dirs in importPathList()
     if (!src && !nameIsUrl) {
-      const moredirs = engine.importPathList();
+      const moredirs = engine.importSearchPaths(
+        QmlWeb.executionContext.importContextId);
       for (let i = 0; i < moredirs.length; i++) {
         file = moredirs[i] + resolvedName;
         src = QmlWeb.getUrlContents(file, true);
@@ -71,7 +72,8 @@ const Qt = {
     component.$imports = tree.$imports;
     component.$file = file; // just for debugging
 
-    engine.loadImports(tree.$imports, component.$basePath);
+    engine.loadImports(tree.$imports, component.$basePath,
+      component.importContextId);
 
     engine.components[name] = component;
     return component;
@@ -90,7 +92,7 @@ const Qt = {
     });
 
     const engine = QmlWeb.engine;
-    engine.loadImports(tree.$imports);
+    engine.loadImports(tree.$imports, undefined, component.importContextId);
 
     const resolvedFile = file || Qt.resolvedUrl("createQmlObject_function");
     component.$basePath = engine.extractBasePath(resolvedFile);

--- a/src/modules/QtQuick/Item.js
+++ b/src/modules/QtQuick/Item.js
@@ -54,7 +54,10 @@ registerQmlType({
       this.dom.style.position = "absolute";
     }
     this.dom.style.pointerEvents = "none";
-    this.dom.className = `${meta.object.$class}${this.id ? ` ${this.id}` : ""}`;
+    // In case the class is qualified, only use the last part for the css class
+    // name.
+    const classComponent = meta.object.$class.split(".").pop();
+    this.dom.className = `${classComponent}${this.id ? ` ${this.id}` : ""}`;
     this.css = this.dom.style;
     this.impl = null; // Store the actually drawn element
 

--- a/src/modules/QtQuick/Loader.js
+++ b/src/modules/QtQuick/Loader.js
@@ -52,6 +52,11 @@ registerQmlType({
     const QMLComponent = QmlWeb.getConstructor("QtQml", "2.0", "Component");
     const meta = { object: tree, context: this, parent: this };
     const qmlComponent = new QMLComponent(meta);
+    qmlComponent.$basePath = QmlWeb.engine.extractBasePath(tree.$file);
+    qmlComponent.$imports = tree.$imports;
+    qmlComponent.$file = tree.$file;
+    QmlWeb.engine.loadImports(tree.$imports, qmlComponent.$basePath,
+      qmlComponent.importContextId);
     const loadedComponent = this.$createComponentObject(qmlComponent, this);
     this.sourceComponent = loadedComponent;
     this.$sourceUrl = newVal;
@@ -62,8 +67,7 @@ registerQmlType({
     const QMLComponent = QmlWeb.getConstructor("QtQml", "2.0", "Component");
     let qmlComponent = newItem;
     if (newItem instanceof QMLComponent) {
-      const meta = { object: newItem.$metaObject, context: this, parent: this };
-      qmlComponent = QmlWeb.construct(meta);
+      qmlComponent = newItem.$createObject(this, {}, this);
     }
     qmlComponent.parent = this;
     this.item = qmlComponent;

--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -46,8 +46,23 @@ describe("QMLEngine.imports", function() {
     };
     expect(f.bind(this)).toThrowError("No constructor found for WebSocket");
   });
+  it("directory imports are local to file, should fail", function() {
+    var f = function() {
+      load("LocalToFile/DirectoryFail", this.div);
+    };
+    expect(f.bind(this)).toThrowError("No constructor found for ImportMe");
+  });
+  it("can find local Component assigned to property when in another directory",
+  function() {
+    var qml = load("LocalComponentAsPropertyInAnotherDir", this.div);
+    expect(qml.value).toBe(67);
+  });
   it("qualified imports from module", function() {
     var qml = load("QualifiedModule", this.div);
+    expect(qml.value).toBe(67);
+  });
+  it("qualified from directory without qmldir file", function() {
+    var qml = load("QualifiedNoQmldir", this.div);
     expect(qml.value).toBe(67);
   });
 });

--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -28,4 +28,26 @@ describe("QMLEngine.imports", function() {
     var qml = load("NoQmldir", this.div);
     expect(qml.value).toBe(67);
   });
+  it("module imports are local to file, should succeed", function() {
+    var f = function() {
+      load("LocalToFile/ModuleSucceed", this.div);
+    };
+    expect(f.bind(this)).not.toThrow();
+  });
+  it("module imports are local to file, should fail 1", function() {
+    var f = function() {
+      load("LocalToFile/ModuleFail1", this.div);
+    };
+    expect(f.bind(this)).toThrowError("No constructor found for WebSocket");
+  });
+  it("module imports are local to file, should fail 2", function() {
+    var f = function() {
+      load("LocalToFile/ModuleFail2", this.div);
+    };
+    expect(f.bind(this)).toThrowError("No constructor found for WebSocket");
+  });
+  it("qualified imports from module", function() {
+    var qml = load("QualifiedModule", this.div);
+    expect(qml.value).toBe(67);
+  });
 });

--- a/tests/QMLEngine/qml/ImportFrom/LocalComponentProperty.qml
+++ b/tests/QMLEngine/qml/ImportFrom/LocalComponentProperty.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Repeater {
+  delegate: ImportMe {}
+}

--- a/tests/QMLEngine/qml/ImportLocalComponentAsPropertyInAnotherDir.qml
+++ b/tests/QMLEngine/qml/ImportLocalComponentAsPropertyInAnotherDir.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+/* The issue that can arise is that LocalComponentProperty ends up with the
+ * same importContextId as this file, so we import "ImportFrom" qualified, so
+ * that a plain "ImportMe" in LocalComponentProperty will fail if it ends up
+ * within this file's context. */
+import "ImportFrom" as ImportFrom
+
+Item {
+  property int value: local_component_property.count ? local_component_property.itemAt(0).value : 0
+  ImportFrom.LocalComponentProperty {
+    id: local_component_property
+    /* Required to set model here, instead of within Repeater, as it causes the
+     * Repeater's delegate to get created in this file's context, instead of
+     * LocalComponentProperty's context. So if the delegate doesn't have an
+     * importContextId set, it will default to this file's, which is incorrect.
+     * */
+    model: 1
+  }
+}

--- a/tests/QMLEngine/qml/ImportLocalToFile/DirectoryFail.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/DirectoryFail.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+import "../ImportFrom"
+
+DirectoryFailSomeComponent {}

--- a/tests/QMLEngine/qml/ImportLocalToFile/DirectoryFailSomeComponent.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/DirectoryFailSomeComponent.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.0
+
+ImportMe {}

--- a/tests/QMLEngine/qml/ImportLocalToFile/ModuleFail1.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/ModuleFail1.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.0
+
+Item {
+    ModuleFailSomeComponent {
+        WebSocket {}
+    }
+}

--- a/tests/QMLEngine/qml/ImportLocalToFile/ModuleFail2.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/ModuleFail2.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.0
+
+Item {
+    ModuleFailSomeComponent {
+    }
+    WebSocket {}
+}

--- a/tests/QMLEngine/qml/ImportLocalToFile/ModuleFailSomeComponent.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/ModuleFailSomeComponent.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+import QtWebSockets 1.0
+
+Item {
+}

--- a/tests/QMLEngine/qml/ImportLocalToFile/ModuleSucceed.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/ModuleSucceed.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.0
+import QtWebSockets 1.0
+
+Item {
+    ModuleSucceedSomeComponent {
+        WebSocket {}
+    }
+    WebSocket {}
+}

--- a/tests/QMLEngine/qml/ImportLocalToFile/ModuleSucceedSomeComponent.qml
+++ b/tests/QMLEngine/qml/ImportLocalToFile/ModuleSucceedSomeComponent.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+
+Item {
+}

--- a/tests/QMLEngine/qml/ImportQualifiedModule.qml
+++ b/tests/QMLEngine/qml/ImportQualifiedModule.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0 as Quick
+
+Quick.Item {
+  property int value: 67
+}

--- a/tests/QMLEngine/qml/ImportQualifiedNoQmldir.qml
+++ b/tests/QMLEngine/qml/ImportQualifiedNoQmldir.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+import "ImportFrom" as ImFr
+
+ImFr.ImportMe {
+
+}

--- a/tests/QtQuick/qml/LoaderComponent.qml
+++ b/tests/QtQuick/qml/LoaderComponent.qml
@@ -1,8 +1,12 @@
 import QtQuick 2.0
 import QtWebSockets 1.0 as WS
+import "LoaderDirectory" as LD
+import "LoaderDirectory"
 
 Item {
   property int value: 42
 
   WS.WebSocket {}
+  LoaderDirectoryComponent {}
+  LD.LoaderDirectoryComponent {}
 }

--- a/tests/QtQuick/qml/LoaderComponent.qml
+++ b/tests/QtQuick/qml/LoaderComponent.qml
@@ -1,5 +1,8 @@
 import QtQuick 2.0
+import QtWebSockets 1.0 as WS
 
 Item {
   property int value: 42
+
+  WS.WebSocket {}
 }

--- a/tests/QtQuick/qml/LoaderDirectory/LoaderDirectoryComponent.qml
+++ b/tests/QtQuick/qml/LoaderDirectory/LoaderDirectoryComponent.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Item {
+  property int value: 43
+}


### PR DESCRIPTION
I have added tests that currently fail with master, but work with these changes.

There are still some uses (like in QMLProperty.set) that should be using the perImportContextConstructors, but it is checking for things like "QMLComponent" that are likely going to be imported into every file with "import QtQuick", so it's not really an issue.