### PR TITLE
@pavelvasev merge: propagate properties of component root objects to outer context

### DIFF
--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -288,8 +288,11 @@ function createProperty(type, obj, propName, options = {}) {
       }
     }
     setupGetterSetter(obj, propName, getter, setter);
-    if (obj.$isComponentRoot)
+    if (obj.$isComponentRoot) {
         setupGetterSetter(obj.$context, propName, getter, setter);
+        if (obj.$context.__proto__)
+          setupGetterSetter(obj.$context.__proto__, propName, getter, setter);
+    }
 }
 
 /**


### PR DESCRIPTION
This merges commit 561b202 by @pavelvasev.

Refs: #32.

/cc @pavelvasev, could you explain what is going on here?