### PR TITLE
@igosoft merge: ListModel updates

### DIFF
--- a/src/modules/QtQuick/ListModel.js
+++ b/src/modules/QtQuick/ListModel.js
@@ -15,7 +15,8 @@ registerQmlType({
     this.$model = new JSItemModel();
 
     this.$itemsChanged.connect(this, function(newVal) {
-        if (firstItem) {
+        this.count = this.$items.length;
+        if (firstItem && newVal.length > 0 ) {
             firstItem = false;
             var roleNames = [];
             var dict = newVal[0];
@@ -25,7 +26,6 @@ registerQmlType({
             }
             this.$model.setRoleNames(roleNames);
         }
-        this.count = this.$items.length;
     });
 
     this.$model.data = function(index, role) {
@@ -36,11 +36,25 @@ registerQmlType({
     }
 
     this.append = function(dict) {
-        this.insert(this.$items.length, dict);
+        var index = this.$items.length;
+        var c = 0;
+
+        if (dict instanceof Array){
+            for (var key in dict) {
+                this.$items.push(dict[key]);
+                c++;
+            }
+        } else {
+            this.$items.push(dict);
+            c = 1;
+        }
+
+        this.$itemsChanged(this.$items);
+        this.$model.rowsInserted(index, index + c);
     }
     this.clear = function() {
-        this.$items = [];
         this.$model.modelReset();
+        this.$items.length = 0;
         this.count = 0;
     }
     this.get = function(index) {


### PR DESCRIPTION
This merges commit 691330f, ref: #223.

This adds support for `append()`-ing an array of elements to `ListModel`, but somewhy doesn't add support for `insert()`-ing an array of elements. Qt QML supports both, afaik.

/cc @igosoft