### PR TITLE
@pavelvasev merge: Component context optimization.. maybe we do not need it?

### DIFF
--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -18,16 +18,18 @@ QMLComponent.getAttachedObject = function() { // static
     return this.$Component;
 }
 
-QMLComponent.prototype.createObject = function(parent, properties) {
+QMLComponent.prototype.createObject = function(parent, properties, componentContext) {
     var oldState = engine.operationState;
     engine.operationState = QMLOperationState.Init;
     // change base path to current component base path
     var bp = engine.$basePath; engine.$basePath = this.$basePath ? this.$basePath : engine.$basePath;
 
+    if (!componentContext) componentContext = this.$context;
+
     var item = construct({
         object: this.$metaObject,
         parent: parent,
-        context: this.$context ? Object.create(this.$context) : new QMLContext(),
+        context: componentContext ? Object.create(componentContext) : new QMLContext(),
         isComponentRoot: true
     });
 

--- a/src/qtcore/qml/qml.js
+++ b/src/qtcore/qml/qml.js
@@ -209,13 +209,13 @@ function construct(meta) {
         var qdirInfo = engine.qmldirs[meta.object.$class]; // Are we have info on that component in some imported qmldir files?
         if (qdirInfo) {
             // We have that component in some qmldir, load it from qmldir's url
-            component = Qt.createComponent( "@" + qdirInfo.url, meta.context);
+            component = Qt.createComponent( "@" + qdirInfo.url);
         }
         else
-            component = Qt.createComponent(meta.object.$class + ".qml", meta.context);
+            component = Qt.createComponent(meta.object.$class + ".qml");
 
         if (component) {
-            var item = component.createObject(meta.parent);
+            var item = component.createObject(meta.parent, {}, meta.context);
 
             if (typeof item.dom != 'undefined')
                 item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");


### PR DESCRIPTION
> if we create context for every createComponent call, maybe it is too
heavy... So we introduce option to provide context in createObject
method which overrides it's component context.

This merges 871fbf03c8dcdda039c5556add2bdfb1b2523c41, ref: #32.

/cc @pavelvasev @Plaristote 