### PR TITLE
Timer set running explicitly

### DIFF
--- a/src/modules/QtQml/Timer.js
+++ b/src/modules/QtQml/Timer.js
@@ -27,19 +27,22 @@ registerQmlType({
         }
     }
 
-    this.start = function() {
-        if (!this.running) {
-            this.running = true;
-            prevTrigger = (new Date).getTime();
+    /* This ensures that if the user toggles the "running" property manually,
+     * the timer will trigger. */
+    this.runningChanged.connect(this, function() {
+        if (this.running) {
+            prevTrigger = new Date().getTime();
             if (this.triggeredOnStart) {
                 trigger();
             }
         }
+    })
+
+    this.start = function() {
+        this.running = true;
     }
     this.stop = function() {
-        if (this.running) {
-            this.running = false;
-        }
+        this.running = false;
     }
     this.restart = function() {
         this.stop();

--- a/tests/QtQuick/Timer.js
+++ b/tests/QtQuick/Timer.js
@@ -28,4 +28,13 @@ describe('QtQuick.Timer', function() {
     var now = new Date();
     qml.start();
   });
+
+  it("can set Timer.running = true to start", function(done) {
+    var qml = load("Running", this.div);
+    qml.yield = function(succeed) {
+      expect(succeed).toBe(true);
+      done();
+    };
+    qml.start();
+  });
 });

--- a/tests/QtQuick/qml/TimerRunning.qml
+++ b/tests/QtQuick/qml/TimerRunning.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.5
+Item {
+  id: root
+
+  function start() {
+    success_timer.running = true
+    fail_timer.start()
+  }
+
+  Timer {
+    id: fail_timer
+    interval: 500
+    onTriggered: {
+      root.yield(false)
+    }
+  }
+
+  Timer {
+    id: success_timer
+    interval: 250
+    onTriggered: {
+      fail_timer.stop()
+      root.yield(true)
+    }
+  }
+}


### PR DESCRIPTION
QML allows `Timer.running` to be set to start/stop a timer: http://doc.qt.io/qt-5/qml-qtqml-timer.html#running-prop

Currently, setting `running` to false works, but not setting `running` to true.