### PR TITLE
QMLProperty: Log thrown exceptions when evaluating a binding

### DIFF
--- a/src/qtcore/qml/QMLProperty.js
+++ b/src/qtcore/qml/QMLProperty.js
@@ -26,7 +26,11 @@ QMLProperty.prototype.update = function() {
 
     var oldVal = this.val;
     evaluatingProperty = this;
-    this.val = this.binding.eval(this.objectScope, this.componentScope);
+    try {
+      this.val = this.binding.eval(this.objectScope, this.componentScope);
+    } catch (e) {
+      console.log("QMLProperty.update binding error:", e, Function.prototype.toString.call(this.binding.eval))
+    }
     evaluatingProperty = undefined;
 
     if (this.animation) {


### PR DESCRIPTION
This is more inline with the C++ QML Engine that logs the error, but
continues working.