### PR TITLE
jsparser: Support importing JavaScript files with ".pragma" statements

### DIFF
--- a/src/qtcore/qml/jsparser.js
+++ b/src/qtcore/qml/jsparser.js
@@ -1,8 +1,10 @@
   global.importJavascriptInContext = function (jsData, $context) {
+    /* Remove any ".pragma" statements, as they are not valid JavaScript */
+    var source = jsData.source.replace(/\.pragma.*(?:\r\n|\r|\n)/, "\n");
     // TODO: pass more objects to the scope?
     (new Function('jsData', '$context', `
       with ($context) {
-        ${jsData.source}
+        ${source}
       }
       ${jsData.exports.map(sym => `$context.${sym} = ${sym};`).join('')}
     `))(jsData, $context);


### PR DESCRIPTION
.pragma statements are not currently respected, but they at least won't
cause the rest of the file to fail to import.