### PR TITLE
MouseArea: Set pressed to false on release, even if outside of MouseArea

### DIFF
--- a/src/modules/QtQuick/MouseArea.js
+++ b/src/modules/QtQuick/MouseArea.js
@@ -36,6 +36,11 @@ registerQmlType({
 
     this.dom.addEventListener("click", e => this.$handleClick(e));
     this.dom.addEventListener("contextmenu", e => this.$handleClick(e));
+    const handleMouseUp = () => {
+      this.pressed = false;
+      this.pressedButtons = 0;
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
     this.dom.addEventListener("mousedown", e => {
       if (!this.enabled) return;
       const mouse = this.$eventToMouse(e);
@@ -43,10 +48,7 @@ registerQmlType({
       this.mouseY = mouse.y;
       this.pressed = true;
       this.pressedButtons = mouse.button;
-    });
-    this.dom.addEventListener("mouseup", () => {
-      this.pressed = false;
-      this.pressedButtons = 0;
+      document.addEventListener("mouseup", handleMouseUp);
     });
     this.dom.addEventListener("mouseover", () => {
       this.containsMouse = true;


### PR DESCRIPTION
This properly mimics QML's behaviour

@ChALkeR Any ideas on how to test this? From a quick Google search, it looks like we would have to use jQuery event handlers and .trigger to simulate events from within Jasmine, but maybe there's a better way.