### PR TITLE
Animation: port to the new module definition syntax (stage-2 variant)

### DIFF
--- a/src/engine/modules.js
+++ b/src/engine/modules.js
@@ -76,7 +76,7 @@ function registerQmlType(options, constructor) {
 
   const descriptor = typeof options === "function" ? {
     module: options.module,
-    name: options.element,
+    name: options.element || options.name,
     versions: options.versions,
     baseClass: options.baseClass,
     enums: options.enums,

--- a/src/modules/QtQuick/Animation.js
+++ b/src/modules/QtQuick/Animation.js
@@ -1,19 +1,18 @@
-QmlWeb.registerQmlType({
-  module: "QtQuick",
-  name: "Animation",
-  versions: /.*/,
-  baseClass: "QtQml.QtObject",
-  enums: {
+QmlWeb.registerQmlType(class Animation {
+  static module = "QtQuick";
+  static versions = /.*/;
+  static baseClass = "QtQml.QtObject";
+  static enums = {
     Animation: { Infinite: -1 },
     Easing: QmlWeb.Easing
-  },
-  properties: {
+  };
+  static properties = {
     alwaysRunToEnd: "bool",
     loops: { type: "int", initialValue: 1 },
     paused: "bool",
     running: "bool"
-  }
-}, class {
+  };
+
   constructor(meta) {
     QmlWeb.callSuper(this, meta);
   }


### PR DESCRIPTION
This ports `Animation` to the new module definition syntax to showcase my proposal in #260.

This is alternative to #261 and uses an even nicer syntax, but requires a ~~`stage-1`~~ `stage-2` transform to support [ES Class Fields & Static Properties](https://github.com/jeffmo/es-class-fields-and-static-properties) ~~`stage-1`~~ `stage-2` proposal. **Upd:** it's `stage-2` now.

`stage-2` means «The committee expects the feature to be developed and eventually included in the standard». See [TC39 Process](https://tc39.github.io/process-document/) for more info on that.

~~I doubt that we want this atm, perhaps we should wait until it reaches `stage-2` or `stage-3`.~~
Not sure if we want to adopt this on the current stage or if we should wait for it to reach `stage-3`, which could take some time.

I landed runtime support for this syntax in 188e9fd (i.e. for passing a `function` to `registerQmlType`).

/cc @akreuzkamp @Plaristote 
