### PR TITLE
qmlstructure.js, import.js: move copyrights notices to LICENSE     

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,10 @@ QmlWeb is licensed under the MIT license, as follows:
 """
 MIT License
 
-Copyright (c) 2012 Lauri Paimen
-Copyright (c) 2013 Anton Kreuzkamp
+Copyright (c) 2011, 2012 Lauri Paimen <lauri@paimen.info>
+Copyright (c) 2013 Anton Kreuzkamp <akreuzkamp@web.de>
+Copyright (c) 2015 Pavel Vasev <pavel.vasev@gmail.com> - initial and working
+                                                         import implementation.
 Copyright (c) 2016-2018 QmlWeb contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/engine/import.js
+++ b/src/engine/import.js
@@ -1,31 +1,3 @@
-/* @license
-
-MIT License
-
-Copyright (c) 2011 Lauri Paimen <lauri@paimen.info>
-Copyright (c) 2015 Pavel Vasev <pavel.vasev@gmail.com> - initial and working
-                                                         import implementation.
-Copyright (c) 2016 QmlWeb contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
-
 /**
  * Get URL contents.
  * @param url {String} Url to fetch.

--- a/src/engine/qmlstructure.js
+++ b/src/engine/qmlstructure.js
@@ -1,29 +1,3 @@
-/* @license
-
-MIT License
-
-Copyright (c) 2011 Lauri Paimen <lauri@paimen.info>
-Copyright (c) 2013 Anton Kreuzkamp <akreuzkamp@web.de>
-Copyright (c) 2016 QmlWeb contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 class QMLMethod extends QmlWeb.QMLBinding {
 }
 


### PR DESCRIPTION
This changes the way how the copyrights notice and the license are included for the qmlstructure.js and import.js files.
    
This does not change the actual copyrights or the license for those files.

/cc @lpaimen @akreuzkamp @pavelvasev — those are your copyrights, so PTAL.

Note: this blocks moving file contents around between files.
