### PR TITLE
Revert passing in meta.context to createObject in construct

### DIFF
--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -247,6 +247,11 @@ function construct(meta) {
         // Currently we support only 1,2 and 4 and use order: 4,1,2
         // TODO: engine.qmldirs is global for all loaded components. That's not qml's original behaviour.
         var qdirInfo = engine.qmldirs[meta.object.$class]; // Are we have info on that component in some imported qmldir files?
+
+        /* This will also be set in applyProperties, but needs to be set here
+         * for Qt.createComponent to have the correct context. */
+        _executionContext = meta.context;
+
         if (qdirInfo) {
             // We have that component in some qmldir, load it from qmldir's url
             component = Qt.createComponent( "@" + qdirInfo.url);

--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -255,7 +255,7 @@ function construct(meta) {
             component = Qt.createComponent(meta.object.$class + ".qml");
 
         if (component) {
-            var item = component.createObject(meta.parent, {}, meta.context);
+            var item = component.createObject(meta.parent);
 
             if (typeof item.dom != 'undefined')
                 item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -18,18 +18,16 @@ QMLComponent.getAttachedObject = function() { // static
     return this.$Component;
 }
 
-QMLComponent.prototype.createObject = function(parent, properties, componentContext) {
+QMLComponent.prototype.createObject = function(parent, properties) {
     var oldState = engine.operationState;
     engine.operationState = QMLOperationState.Init;
     // change base path to current component base path
     var bp = engine.$basePath; engine.$basePath = this.$basePath ? this.$basePath : engine.$basePath;
 
-    if (!componentContext) componentContext = this.$context;
-
     var item = construct({
         object: this.$metaObject,
         parent: parent,
-        context: componentContext ? Object.create(componentContext) : new QMLContext(),
+        context: this.$context ? Object.create(this.$context) : new QMLContext(),
         isComponentRoot: true
     });
 

--- a/tests/QMLEngine/qml/ScopeComponentId.qml
+++ b/tests/QMLEngine/qml/ScopeComponentId.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.0
+
+ScopeComponentIdSomeComponent {
+  id: some_component
+
+  property int foo: 42
+  property int bar: some_component.foo
+}

--- a/tests/QMLEngine/qml/ScopeComponentIdSomeComponent.qml
+++ b/tests/QMLEngine/qml/ScopeComponentIdSomeComponent.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+
+Item {
+}

--- a/tests/QMLEngine/scope.js
+++ b/tests/QMLEngine/scope.js
@@ -65,4 +65,11 @@ describe("QMLEngine.scope", function() {
       expect(qml.boo).toBe("42");
     }
   );
+
+  it('item id of a component should be in scope',
+    function() {
+      var qml = load('ComponentId', this.div);
+      expect(qml.bar).toBe(42);
+    }
+  );
 });


### PR DESCRIPTION
This was added in 2c7b240

By forcing the context for createObject in "construct" to that of the
calling context, it stops a new context Object from being created with
the Component's context as a prototype.  This will then cause changes
to the newly created Item's context to creep into the passed in
componentContext.