### PR TITLE
Component: set Item.parent in construct

### DIFF
--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -262,6 +262,12 @@ function construct(meta) {
     // Apply properties (Bindings won't get evaluated, yet)
     applyProperties(meta.object, item, item, item.$context);
 
+    // Not checking if item inherits from Item because non-Item items may have
+    // a "parent" property (e.g. Timer).
+    if (meta.parent && item.hasOwnProperty("parent")) {
+      item.parent = meta.parent
+    }
+
     return item;
 }
 

--- a/src/modules/QtQuick/Item.js
+++ b/src/modules/QtQuick/Item.js
@@ -41,7 +41,10 @@ function QMLItem(meta) {
     this.dataChanged.connect(this, function(newData) {
         for (var i in newData) {
             var child = newData[i];
-            if (child.hasOwnProperty("parent")) // Seems to be an Item. TODO: Use real inheritance and ask using instanceof.
+
+            // Not checking if item inherits from Item because non-Item items
+            // may have a "parent" property (e.g. Timer).
+            if (child.hasOwnProperty("parent"))
                 child.parent = this; // This will also add it to children.
             else
                 this.resources.push(child);

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -29,4 +29,11 @@ describe('QMLEngine.basic', function() {
     expect(qml.inner3).toBe(qml.current + 'foo/foo/lol/');
     expect(qml.full).toBe('http://example.com/bar');
   });
+
+  it('createObject', function() {
+    var qml = load('CreateObject', this.div);
+    expect(qml.children.length).toBe(1);
+    expect(qml.children[0].q).toBe(22);
+    expect(this.div.innerText).toBe("variable from context = 42");
+  });
 });

--- a/tests/QMLEngine/qml/BasicCreateObject.qml
+++ b/tests/QMLEngine/qml/BasicCreateObject.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.2
+
+Item {
+  id: item
+  property string contextVar: "42";
+
+  Component.onCompleted: {
+    var c = Qt.createComponent("BasicCreateObjectSomeComponent.qml")
+    c.createObject(item)
+  }
+}

--- a/tests/QMLEngine/qml/BasicCreateObjectSomeComponent.qml
+++ b/tests/QMLEngine/qml/BasicCreateObjectSomeComponent.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.0
+
+Rectangle {
+  color: 'green'
+  width: 320
+  height: 32
+
+  property var q: 22
+
+  Text {
+    color:'gold'
+    text: 'variable from context = ' + contextVar
+  }
+}

--- a/tests/Render/Simple/PropertyGrid.qml
+++ b/tests/Render/Simple/PropertyGrid.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.0
+import "../../RenderQml"
 
 Grid {
   columns: 4
   spacing: 3
   Rectangle { color: "red"; width: 5; height: 5 }
-  Rectangle { color: 'green'; width: 6; height: 3 }
+  PropertyGridComponent { color: 'green'; width: 6; height: 3 }
   Rectangle { color: "#00f"; width: 2; height: 6 }
-  Rectangle { color: 'cy' + 'an'; width: 1; height: 1 }
+  PropertyGridComponent { color: 'cy' + 'an'; width: 1; height: 1 }
   Rectangle { color: false ? 'green' : "magenta"; width: 4; height: 4 }
 }

--- a/tests/RenderQml/PropertyGridComponent.qml
+++ b/tests/RenderQml/PropertyGridComponent.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+
+Rectangle {
+}


### PR DESCRIPTION
This mirrors QML behaviour, which doesn't require the user to manually
set the item's parent after calling 'createObject'.

Currently, anywhere 'createObject' is called internally in qmlweb, the
item's 'parent' is manually set afterward, or the newly created items are
part of the default 'data' property, and 'QMLItem.dataChanged' does the
setting of the 'parent' property.