### PR TITLE
gulpfile: separate coverage task from test task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ cache:
   directories:
     - $HOME/.npm/
     - node_modules
-before_install:
-  - npm install -g codecov
-after_success:
-  - codecov
+matrix:
+  include:
+    - node_js: "4"
+      script: npm run coverage
+      before_install:
+        - npm install -g codecov
+      after_success:
+        - codecov

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -136,9 +136,19 @@ gulp.task('lint-tests', () =>
 
 gulp.task('lint', ['lint-tests']);
 
-gulp.task('test', ['lint', 'build-covered'], done => {
+gulp.task('test', ['lint', 'build-dev'], done => {
   new karma.Server({
     singleRun: true,
+    configFile: path.join(__dirname, 'karma.conf.js')
+  }, code => {
+    process.exit(code);
+  }).start();
+});
+
+gulp.task('coverage', ['lint', 'build-covered'], done => {
+  new karma.Server({
+    singleRun: true,
+    coverageEnabled: true,
     configFile: path.join(__dirname, 'karma.conf.js')
   }, code => {
     process.exit(code);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,9 @@ module.exports = function(config) {
     basePath: '',
     frameworks: ['jasmine'],
     files: [
-      'tmp/qt.covered.js',
+      config.coverageEnabled ? 'tmp/qt.covered.js' : 'lib/qt.js',
+      { pattern: 'lib/*.js', included: false },
+      { pattern: 'lib/*.js.map', included: false },
       { pattern: 'tmp/qmlweb.*.js', included: false },
       { pattern: 'tmp/*.js.map', included: false },
       'tests/common.js',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "lint": "gulp lint",
     "test": "gulp test",
+    "coverage": "gulp coverage",
     "build": "gulp build",
     "watch": "gulp watch"
   },


### PR DESCRIPTION
This makes `npm test` much faster.

Coverage could be obtained by running `npm coverage`.