### PR TITLE
qmlstructure: deprecate qmlobjdef, use qmlprop instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-spec-reporter": "~0.0.24",
     "phantomjs-prebuilt": "^2.1.4",
-    "qmlweb-parser": "^0.2.2",
+    "qmlweb-parser": "^0.3.0",
     "remark-cli": "^2.0.0",
     "remark-lint": "^5.0.0"
   },


### PR DESCRIPTION
`qmlobjdef` supports only two components, a different format is needed to support assignments like `Drag.hotSpot.x: width / 2`.

Let's just use `qmlprop` with `name = 'Drag.hotSpot.x'` for that, instead of defining a separate token type for properties with two components.

After being merged here, a change on the parser side would be needed to support `Drag.hotSpot.x`.
Refs: https://github.com/qmlweb/qmlweb-parser/pull/17

/cc @akreuzkamp 

