### PR TITLE
Introduce QmlWeb variable, don't pollute global

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ const istanbul = require('gulp-istanbul');
 const path = require('path');
 
 const qtcoreSources = [
+  'src/qtcore/QmlWeb.js',
   'src/qtcore/QMLBinding.js',
   'src/qtcore/qmlstructure.js',
   'src/qtcore/import.js',

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -62,7 +62,7 @@ function QMLComponent(meta) {
           js = qrc[src];
         else {
           loadParser();
-          js = qmlweb_jsparse(getUrlContents(src));
+          js = QmlWeb.jsparse(getUrlContents(src));
         }
         if (importDesc[3] !== "") {
           $context[importDesc[3]] = {};

--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -1,4 +1,4 @@
-global.Qt = {
+const Qt = {
   rgba: function(r,g,b,a) {
     return "rgba("
       + Math.round(r * 255) + ","
@@ -354,4 +354,6 @@ global.Qt = {
   ScrollBarAsNeeded: 0,
   ScrollBarAlwaysOff: 1,
   ScrollBarAlwaysOn: 2
-}
+};
+
+QmlWeb.Qt = Qt;

--- a/src/modules/QtQuick/SystemPalette.js
+++ b/src/modules/QtQuick/SystemPalette.js
@@ -4,14 +4,14 @@ window.SystemPalette = {
   Disabled: "disabled"
 };
 
-window.platformsDetectors = [
+const platformsDetectors = [
   //{ name: 'W8',      regexp: /Windows NT 6\.2/ },
   //{ name: 'W7',      regexp: /Windows NT 6\.1/ },
   //{ name: 'Windows', regexp: /Windows NT/ },
   { name: 'OSX',     regexp: /Macintosh/ }
 ];
 
-window.systemPalettes = {};
+const systemPalettes = {};
 
 registerQmlType({
   module: 'QtQuick',
@@ -48,7 +48,7 @@ registerQmlType({
   }
 });
 
-window.systemPalettes['OSX'] = {
+systemPalettes['OSX'] = {
         'active': {
           'alternateBase': '#f6f6f6',
           'base':          '#ffffff',
@@ -98,3 +98,6 @@ window.systemPalettes['OSX'] = {
           'windowText':    '#7f7f7f'
         }
 };
+
+QmlWeb.systemPalettes = systemPalettes;
+QmlWeb.platformsDetectors = platformsDetectors;

--- a/src/qtcore/AutoLoader.js
+++ b/src/qtcore/AutoLoader.js
@@ -6,9 +6,9 @@ window.addEventListener('load', () => {
     var source  = metaTag.getAttribute('data-qml');
 
     if (source != null) {
-      global.qmlEngine = new QMLEngine();
-      qmlEngine.loadFile(source);
-      qmlEngine.start();
+      QmlWeb.qmlEngine = new QMLEngine();
+      QmlWeb.qmlEngine.loadFile(source);
+      QmlWeb.qmlEngine.start();
       break ;
     }
   }

--- a/src/qtcore/QMLBinding.js
+++ b/src/qtcore/QMLBinding.js
@@ -25,8 +25,8 @@ class QMLBinding {
  * Compile binding. Afterwards you may call binding.eval to evaluate.
  */
   compile() {
-    this.eval = new Function('__executionObject', '__executionContext', "_executionContext = __executionContext; with(__executionContext) with(__executionObject) " + ( this.isFunction ? "" : "return " ) + this.src);
+    this.eval = new Function('__executionObject', '__executionContext', "_executionContext = __executionContext; with(QmlWeb) with(__executionContext) with(__executionObject) " + ( this.isFunction ? "" : "return " ) + this.src);
   }
 }
 
-global.QMLBinding = QMLBinding;
+QmlWeb.QMLBinding = QMLBinding;

--- a/src/qtcore/QMLEngine.js
+++ b/src/qtcore/QMLEngine.js
@@ -11,7 +11,7 @@
 var engine = null;
 
 // QML engine. EXPORTED.
-QMLEngine = function (element, options) {
+const QMLEngine = function (element, options) {
 //----------Public Members----------
     this.fps = 60;
     this.$interval = Math.floor(1000 / this.fps); // Math.floor, causes bugs to timing?
@@ -77,7 +77,7 @@ QMLEngine = function (element, options) {
         if (src) {
             loadParser();
             console.log('Loading file [', file, ']');
-            qrc[file] = qmlweb_parse(src, qmlweb_parse.QMLDocument);
+            qrc[file] = QmlWeb.parse(src, QmlWeb.parse.QMLDocument);
         } else {
             console.log('Can not load file [', file, ']');
         }
@@ -205,12 +205,12 @@ QMLEngine = function (element, options) {
       A1: Seems it doesn't matter. Seems we may just save name with dot-inside right to qmldirs, and it may be used by construct() seamlessly. Check it..
 
       Q2: How we may access component object from here, to store qmldirs info in components logical scope, and not at engine scope?
-      A2: Probably, answer is in Component.js and in global.loadImports
+      A2: Probably, answer is in Component.js and in QmlWeb.loadImports
 
       TODO 
       * We have to keep output in component scope, not in engine scope.
       * We have to add module "as"-names to component's names (which is possible after keeping imports in component scope).
-      * Determine how this stuff is related to `global.loadImports`
+      * Determine how this stuff is related to `QmlWeb.loadImports`
       * Check A1
       * Make a complete picture of what going in with imports, including Component.js own imports loading
       * Note importJs method in import.js 
@@ -609,3 +609,5 @@ QMLEngine.prototype.callCompletedSignals = function() {
      handler();
   }
 };
+
+QmlWeb.QMLEngine = QMLEngine;

--- a/src/qtcore/QMLOperationState.js
+++ b/src/qtcore/QMLOperationState.js
@@ -1,5 +1,7 @@
-QMLOperationState = {
+const QMLOperationState = {
     Idle: 1,
     Init: 2,
     Running: 3
 };
+
+QmlWeb.QMLOperationState = QMLOperationState;

--- a/src/qtcore/QmlWeb.js
+++ b/src/qtcore/QmlWeb.js
@@ -1,0 +1,5 @@
+const QmlWeb = {
+  qrc: {}
+};
+
+global.QmlWeb = QmlWeb;

--- a/src/qtcore/import.js
+++ b/src/qtcore/import.js
@@ -27,14 +27,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 /**
- * Get URL contents. EXPORTED.
+ * Get URL contents.
  * @param url {String} Url to fetch.
  * @param skipExceptions {bool} when turned on, ignore exeptions and return false. This feature is used by readQmlDir.
  * @private
  * @return {mixed} String of contents or false in errors.
  */
-getUrlContents = function (url, skipExceptions) {
-    if (typeof urlContentCache[url] == 'undefined') {
+function getUrlContents(url, skipExceptions) {
+    if (typeof QmlWeb.urlContentCache[url] == 'undefined') {
       var xhr = new XMLHttpRequest();
       xhr.open("GET", url, false);
 
@@ -47,15 +47,15 @@ getUrlContents = function (url, skipExceptions) {
           console.log("Retrieving " + url + " failed: " + xhr.responseText, xhr);
           return false;
       }
-      urlContentCache[url] = xhr.responseText;
+      QmlWeb.urlContentCache[url] = xhr.responseText;
     }
-    return urlContentCache[url];
+    return QmlWeb.urlContentCache[url];
 }
-if (typeof global.urlContentCache == 'undefined')
-  global.urlContentCache = {};
+if (typeof QmlWeb.urlContentCache == 'undefined')
+  QmlWeb.urlContentCache = {};
 
 /**
- * Read qmldir spec file at directory. EXPORTED.
+ * Read qmldir spec file at directory.
  * @param url Url of the directory
  * @return {Object} Object, where .internals lists qmldir internal references
  *                          and .externals lists qmldir external references.
@@ -76,7 +76,7 @@ if (typeof global.urlContentCache == 'undefined')
    Also please look at notes and TODO's in qtcore.js::loadImports() and qtcore.js::construct() methods.
 */
  
-readQmlDir = function (url) {
+function readQmlDir(url) {
     // in case 'url' is empty, do not attach "/"
     // Q1: when this happen?
     var qmldirFileUrl = url.length > 0 ? (url + "/qmldir") : "qmldir";

--- a/src/qtcore/jsparser.js
+++ b/src/qtcore/jsparser.js
@@ -1,11 +1,13 @@
-  global.importJavascriptInContext = function (jsData, $context) {
+  function importJavascriptInContext(jsData, $context) {
     /* Remove any ".pragma" statements, as they are not valid JavaScript */
     var source = jsData.source.replace(/\.pragma.*(?:\r\n|\r|\n)/, "\n");
     // TODO: pass more objects to the scope?
     (new Function('jsData', '$context', `
-      with ($context) {
+      with(QmlWeb) with ($context) {
         ${source}
       }
       ${jsData.exports.map(sym => `$context.${sym} = ${sym};`).join('')}
     `))(jsData, $context);
   }
+
+QmlWeb.importJavascriptInContext = importJavascriptInContext;

--- a/src/qtcore/qml.js
+++ b/src/qtcore/qml.js
@@ -30,14 +30,14 @@ const modules = {
 const dependants = {};
 
 // Helper. Adds a type to the constructor list
-global.registerGlobalQmlType = function (name, type) {
-  global[type.name]  = type;
+function registerGlobalQmlType(name, type) {
+  QmlWeb[type.name]  = type;
   constructors[name] = type;
   modules.Main[name] = type;
 };
 
 // Helper. Register a type to a module
-global.registerQmlType = function(options, constructor) {
+function registerQmlType(options, constructor) {
   if (constructor !== undefined) {
     options.constructor = constructor;
   }
@@ -108,12 +108,12 @@ global.registerQmlType = function(options, constructor) {
 
   const id = [options.module, options.name].join('.');
   if (dependants.hasOwnProperty(id)) {
-    dependants[id].forEach(opt => global.registerQmlType(opt));
+    dependants[id].forEach(opt => registerQmlType(opt));
     dependants[id].length = 0;
   }
 };
 
-global.getConstructor = function (moduleName, version, name) {
+function getConstructor(moduleName, version, name) {
   if (typeof modules[moduleName] != 'undefined') {
     for (var i = 0 ; i < modules[moduleName].length ; ++i) {
       var type = modules[moduleName][i];
@@ -125,7 +125,7 @@ global.getConstructor = function (moduleName, version, name) {
   return null;
 };
 
-global.collectConstructorsForModule = function (moduleName, version) {
+function collectConstructorsForModule(moduleName, version) {
   var constructors = {};
 
   if (typeof modules[moduleName] == 'undefined') {
@@ -142,7 +142,7 @@ global.collectConstructorsForModule = function (moduleName, version) {
   return constructors;
 };
 
-global.mergeObjects = function (obj1, obj2) {
+function mergeObjects(obj1, obj2) {
   var mergedObject = {};
 
   if (typeof obj1 != 'undefined' && obj1 != null) {
@@ -154,9 +154,9 @@ global.mergeObjects = function (obj1, obj2) {
   return mergedObject;
 }
 
-global.perContextConstructors = {};
+const perContextConstructors = {};
 
-global.loadImports = function (self, imports) {
+function loadImports(self, imports) {
   constructors = mergeObjects(modules.Main, null);
   if (imports.filter(row => row[1] === 'QtQml').length === 0 &&
       imports.filter(row => row[1] === 'QtQuick').length === 1) {
@@ -176,7 +176,7 @@ global.loadImports = function (self, imports) {
   perContextConstructors[self.objectId] = constructors;
 }
 
-global.inherit = function(constructor, baseClass) {
+function inherit(constructor, baseClass) {
   var oldProto = constructor.prototype;
   constructor.prototype = Object.create(baseClass.prototype);
   Object.getOwnPropertyNames(oldProto).forEach(prop => {
@@ -479,7 +479,7 @@ function applyProperties(metaObject, item, objectScope, componentScope) {
 }
 
 // ItemModel. EXPORTED.
-JSItemModel = function() {
+const JSItemModel = function() {
     this.roleNames = [];
 
     this.setRoleNames = function(names) {
@@ -506,7 +506,8 @@ JSItemModel = function() {
     this.modelReset = Signal();
 }
 
-// -----------------------------------------------------------------------------
-// Stuff below defines QML things
-// -----------------------------------------------------------------------------
-
+QmlWeb.registerGlobalQmlType = registerGlobalQmlType;
+QmlWeb.registerQmlType = registerQmlType;
+QmlWeb.getConstructor = getConstructor;
+QmlWeb.loadImports = loadImports;
+QmlWeb.JSItemModel = JSItemModel;

--- a/src/qtcore/qmlstructure.js
+++ b/src/qtcore/qmlstructure.js
@@ -233,13 +233,13 @@ function convertToEngine(tree) {
 // Function to parse qml and output tree expected by engine
 function parseQML(src, file) {
     loadParser();
-    qmlweb_parse.nowParsingFile = file;
-    var parsetree = qmlweb_parse(src, qmlweb_parse.QmlDocument);
+    QmlWeb.parse.nowParsingFile = file;
+    var parsetree = QmlWeb.parse(src, QmlWeb.parse.QmlDocument);
     return convertToEngine(parsetree);
 }
 
 function loadParser() {
-  if (typeof qmlweb_parse !== 'undefined')
+  if (typeof QmlWeb.parse !== 'undefined')
     return;
 
   console.log('Loading parser...');
@@ -255,6 +255,10 @@ function loadParser() {
           throw new Error('Could not load QmlWeb parser!');
       }
       (new Function(xhr.responseText))();
+      // TODO: remove in 0.2, qmlweb.parser should set
+      //  QmlWeb.parse and QmlWeb.jsparse if QmlWeb is defined
+      QmlWeb.parse = QmlWeb.parse || qmlweb_parse;
+      QmlWeb.jsparse = QmlWeb.jsparse || qmlweb_jsparse;
       return;
     }
   }

--- a/src/qtcore/qrc.js
+++ b/src/qtcore/qrc.js
@@ -1,1 +1,2 @@
-global.qrc = {};
+// TODO: remove global.qrc support in 0.2
+global.qrc = QmlWeb.qrc;

--- a/src/qtcore/signal.js
+++ b/src/qtcore/signal.js
@@ -7,7 +7,7 @@
  *               currently ignored.
  * @param options Options that allow finetuning of the signal.
  */
-global.Signal = function Signal(params, options) {
+function Signal(params, options) {
     options = options || {};
     var connectedSlots = [];
     var obj = options.obj
@@ -82,3 +82,4 @@ global.Signal = function Signal(params, options) {
     return signal;
 }
 
+QmlWeb.Signal = Signal;

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -1,6 +1,6 @@
 describe('QMLEngine.basic', function() {
   it('present', function() {
-    expect(!!QMLEngine).toBe(true);
+    expect(!!QmlWeb && !!QmlWeb.QMLEngine).toBe(true);
   });
 
   setupDivElement();

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,5 +1,5 @@
 function loadQmlFile(file, div, opts) {
-  var engine = new QMLEngine(div, opts || {});
+  var engine = new QmlWeb.QMLEngine(div, opts || {});
   engine.loadFile(file);
   engine.start();
   document.body.appendChild(div);
@@ -13,7 +13,7 @@ function prefixedQmlLoader(prefix) {
 }
 
 function loadQml(src, div, opts) {
-  var engine = new QMLEngine(div, opts || {});
+  var engine = new QmlWeb.QMLEngine(div, opts || {});
   engine.loadQML(src);
   engine.start();
   document.body.appendChild(div);

--- a/tests/qmlweb.js
+++ b/tests/qmlweb.js
@@ -12,8 +12,8 @@ require('jsdom').env('', (err, window) => {
   const file = process.argv[process.argv.length - 1];
   const div = document.createElement('div');
   document.body.appendChild(div);
-  var engine = new QMLEngine(div, {});
-  urlContentCache[file] = fs.readFileSync(file, 'utf-8');
+  var engine = new QmlWeb.QMLEngine(div, {});
+  QmlWeb.urlContentCache[file] = fs.readFileSync(file, 'utf-8');
   engine.loadFile(file);
   engine.start();
 });


### PR DESCRIPTION
Fixes: https://github.com/qmlweb/qmlweb/issues/51

We might want to add more methods/variables to the QmlWeb variable.
This does not deal with enums on a purpose, those should be covered by #271.

/cc @Plaristote @akreuzkamp @stephenmdangelo — PTAL.