### PR TITLE
Timer: Added parent property

### DIFF
--- a/src/modules/QtQml/Timer.js
+++ b/src/modules/QtQml/Timer.js
@@ -5,6 +5,7 @@ registerQmlType({
   baseClass: "QtObject",
   properties: {
     interval: { type: "int", initialValue: 1000 },
+    parent: { type: "QtObject", readOnly: true },
     repeat: "bool",
     running: "bool",
     triggeredOnStart: "bool"
@@ -15,6 +16,8 @@ registerQmlType({
 }, class {
   constructor(meta) {
     callSuper(this, meta);
+
+    this.$properties.parent.set(this.$parent, QmlWeb.QMLProperty.ReasonInit);
 
     /* This ensures that if the user toggles the "running" property manually,
      * the timer will trigger. */

--- a/tests/QtQuick/Timer.js
+++ b/tests/QtQuick/Timer.js
@@ -37,4 +37,9 @@ describe("QtQuick.Timer", function() {
     };
     qml.start();
   });
+
+  it("Timer parent property", function() {
+    var qml = load("ParentProperty", this.div);
+    expect(qml.timer.value).toBe(42);
+  });
 });

--- a/tests/QtQuick/qml/TimerParentProperty.qml
+++ b/tests/QtQuick/qml/TimerParentProperty.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+
+Item {
+  property int value: 42
+
+  property alias timer: _timer
+  Timer {
+    id: _timer
+    property int value: parent.value
+  }
+}


### PR DESCRIPTION
C++ QML has the parent property explicitly defined for Timer components,
since Timer doesn't inherit from Item:

https://github.com/qt/qtdeclarative/blob/5.7.0/src/qml/types/qqmltimer_p.h#L72