### PR TITLE
Export callSuper and createProperty via QmlWeb

### DIFF
--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -482,3 +482,5 @@ QmlWeb.registerGlobalQmlType = registerGlobalQmlType;
 QmlWeb.registerQmlType = registerQmlType;
 QmlWeb.getConstructor = getConstructor;
 QmlWeb.loadImports = loadImports;
+QmlWeb.callSuper = callSuper;
+QmlWeb.createProperty = createProperty;


### PR DESCRIPTION
This allows new custom QML Components to be defined in .js files outside
of lib/qt.js.