### PR TITLE
.eslintrc: Warn on single quotes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,7 +83,7 @@ rules:
   prefer-rest-params: 2
   prefer-template: 2
   quote-props: [0, "as-needed"]
-  quotes: [0, "single"]
+  quotes: [1, "single"]
   radix: 2
   semi: 2
   semi-spacing: 2


### PR DESCRIPTION
@ChALkeR mentioned (https://github.com/qmlweb/qmlweb/pull/293#discussion_r70023304) that we may want to move to using all single quotes and should prefer single quotes in the interim.  This will help anyone writing new code to adhere to that style (and `eslint --fix` it) without making `lint-tests` fail.