### PR TITLE
Component: set Item.parent in createObject - alternative

### DIFF
--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -176,7 +176,7 @@ class QMLEngine {
     component.$imports = tree.$imports; // for later use
     component.$file = file; // just for debugging
 
-    this.rootObject = component.createObject(parentComponent);
+    this.rootObject = component.$createObject(parentComponent);
     component.finalizeImports(this.rootContext());
     this.$initializePropertyBindings();
 

--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -252,7 +252,7 @@ function construct(meta) {
             component = Qt.createComponent(meta.object.$class + ".qml");
 
         if (component) {
-            var item = component.createObject(meta.parent);
+            var item = component.$createObject(meta.parent);
 
             if (typeof item.dom != 'undefined')
                 item.dom.className += " " + meta.object.$class + (meta.object.id ? " " + meta.object.id : "");

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -62,7 +62,7 @@ class QMLComponent {
       }
     }
   }
-  createObject(parent, properties = {}) {
+  $createObject(parent, properties = {}) {
     const engine = QmlWeb.engine;
     const oldState = engine.operationState;
     engine.operationState = QmlWeb.QMLOperationState.Init;
@@ -86,6 +86,16 @@ class QMLComponent {
     engine.$basePath = bp;
 
     engine.operationState = oldState;
+    return item;
+  }
+  createObject(parent, properties = {}) {
+    const item = this.$createObject(parent, properties);
+    const QMLItem = QmlWeb.getConstructor("QtQuick", "2.0", "Item");
+
+    if (item instanceof QMLItem) {
+      item.$properties.parent.set(parent, QmlWeb.QMLProperty.ReasonInit);
+    }
+
     return item;
   }
   static getAttachedObject() {

--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -99,8 +99,6 @@ const Qt = {
     component.$file = resolvedFile;
 
     const obj = component.createObject(parent);
-    obj.parent = parent;
-    parent.childrenChanged();
 
     const QMLOperationState = QmlWeb.QMLOperationState;
     if (engine.operationState !== QMLOperationState.Init &&

--- a/src/modules/QtQuick/Loader.js
+++ b/src/modules/QtQuick/Loader.js
@@ -94,7 +94,6 @@ registerQmlType({
   }
   $createComponentObject(qmlComponent, parent) {
     const newComponent = qmlComponent.createObject(parent);
-    newComponent.parent = parent;
     qmlComponent.finalizeImports();
     if (QmlWeb.engine.operationState !== QmlWeb.QMLOperationState.Init) {
       // We don't call those on first creation, as they will be called

--- a/src/modules/QtQuick/Repeater.js
+++ b/src/modules/QtQuick/Repeater.js
@@ -145,7 +145,7 @@ registerQmlType({
     const model = this.$getModel();
     let index;
     for (index = startIndex; index < endIndex; index++) {
-      const newItem = this.delegate.createObject();
+      const newItem = this.delegate.$createObject();
       createProperty("int", newItem, "index", { initialValue: index });
       newItem.parent = this.parent;
 

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -41,4 +41,11 @@ describe("QMLEngine.basic", function() {
     var qml = load("SignalDisconnect", this.div);
     expect(qml.log).toBe("i12i2");
   });
+
+  it("createObject", function() {
+    var qml = load("CreateObject", this.div);
+    expect(qml.children.length).toBe(1);
+    expect(qml.children[0].q).toBe(22);
+    expect(this.div.innerText).toBe("variable from context = 42");
+  });
 });

--- a/tests/QMLEngine/qml/BasicCreateObject.qml
+++ b/tests/QMLEngine/qml/BasicCreateObject.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.2
+
+Item {
+  id: item
+  property string contextVar: "42";
+
+  Component.onCompleted: {
+    var c = Qt.createComponent("BasicCreateObjectSomeComponent.qml")
+    c.createObject(item)
+  }
+}

--- a/tests/QMLEngine/qml/BasicCreateObjectSomeComponent.qml
+++ b/tests/QMLEngine/qml/BasicCreateObjectSomeComponent.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.0
+
+Rectangle {
+  color: 'green'
+  width: 320
+  height: 32
+
+  property var q: 22
+
+  Text {
+    color:'gold'
+    text: 'variable from context = ' + contextVar
+  }
+}

--- a/tests/Render/Simple/PropertyGrid.qml
+++ b/tests/Render/Simple/PropertyGrid.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.0
+import "../../RenderQml"
 
 Grid {
   columns: 4
   spacing: 3
   Rectangle { color: "red"; width: 5; height: 5 }
-  Rectangle { color: 'green'; width: 6; height: 3 }
+  PropertyGridComponent { color: 'green'; width: 6; height: 3 }
   Rectangle { color: "#00f"; width: 2; height: 6 }
-  Rectangle { color: 'cy' + 'an'; width: 1; height: 1 }
+  PropertyGridComponent { color: 'cy' + 'an'; width: 1; height: 1 }
   Rectangle { color: false ? 'green' : "magenta"; width: 4; height: 4 }
 }

--- a/tests/RenderQml/PropertyGridComponent.qml
+++ b/tests/RenderQml/PropertyGridComponent.qml
@@ -1,0 +1,4 @@
+import QtQuick 2.0
+
+Rectangle {
+}


### PR DESCRIPTION
This is an alternative approach to the issue, that #275 tries to fix.
This approach isn't very nice, either, but I consider it at least a bit better.

The issue I see with the other approach is that it sets `parent` (including all its consequences with inserting it into the dom, etc.) in `construct` just to override it later, in case it wasn't supposed to.