### PR TITLE
engine/qml: Fix typo when creating declarative signals

### DIFF
--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -214,7 +214,7 @@ function callSuper(self, meta) {
   }
   if (info.signals) {
     Object.keys(info.signals).forEach(name => {
-      const params = info.properties[name];
+      const params = info.signals[name];
       self[name] = Signal(params);
     });
   }

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -29,4 +29,10 @@ describe("QMLEngine.basic", function() {
     expect(qml.inner3).toBe(qml.current + "foo/foo/lol/");
     expect(qml.full).toBe("http://example.com/bar");
   });
+
+  it("signal parameters", function() {
+    var qml = load("SignalParameters", this.div);
+    expect(qml.propA).toBe(42);
+    expect(qml.propB).toBe("foo");
+  });
 });

--- a/tests/QMLEngine/qml/BasicSignalParameters.qml
+++ b/tests/QMLEngine/qml/BasicSignalParameters.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+
+Item {
+  id: item
+
+  signal someSignal(int a, string b)
+
+  property int propA
+  property string propB
+
+  onSomeSignal: {
+    propA = a
+    propB = b
+  }
+
+  Component.onCompleted: {
+    item.someSignal(42, "foo")
+  }
+}


### PR DESCRIPTION
This was causing parameters in signals to not be accessible in slots.