### PR TITLE
QtQuick/Text: Move span to document body before calculating implicit size

### DIFF
--- a/src/modules/QtQuick/Text.js
+++ b/src/modules/QtQuick/Text.js
@@ -116,6 +116,7 @@ registerQmlType({
     this.text = "";
 
     this.textChanged.connect(this, updateImplicit);
+    this.wrapModeChanged.connect(this, updateImplicit);
     this.font.boldChanged.connect(this, updateImplicit);
     this.font.weightChanged.connect(this, updateImplicit);
     this.font.pixelSizeChanged.connect(this, updateImplicit);
@@ -128,10 +129,22 @@ registerQmlType({
 
     function updateImplicit() {
         if (typeof this.text == undefined || this.text === "" || !this.dom) {
-             this.implicitHeigh = this.implicitWidth = 0;
+             this.implicitHeight = this.implicitWidth = 0;
         } else {
-            this.implicitHeight = fc.offsetHeight;
-            this.implicitWidth = fc.offsetWidth;
+            /* Need to move the child out of it's parent so that it can
+             * properly recalculate it's "natural" offsetWidth/offsetHeight
+             * */
+            if (this.$isUsingImplicitWidth) {
+                document.body.appendChild(fc);
+            }
+            var fc_offsetHeight = fc.offsetHeight;
+            var fc_offsetWidth = fc.offsetWidth;
+            if (this.$isUsingImplicitWidth) {
+                this.dom.appendChild(fc);
+            }
+
+            this.implicitHeight = fc_offsetHeight;
+            this.implicitWidth = fc_offsetWidth;
         }
     }
   }

--- a/tests/QtQuick/Text.js
+++ b/tests/QtQuick/Text.js
@@ -1,0 +1,10 @@
+describe("QtQuick.Text", function() {
+  setupDivElement();
+
+  var load = prefixedQmlLoader("QtQuick/qml/Text");
+  it("implicit size", function() {
+    var qml = load("ImplicitSize", this.div);
+    expect(qml.text_item.width).toBeGreaterThan(0);
+  });
+});
+

--- a/tests/QtQuick/qml/TextImplicitSize.qml
+++ b/tests/QtQuick/qml/TextImplicitSize.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+
+Item {
+  property alias text_item: _text_item
+  Rectangle {
+    Text {
+      id: _text_item
+      text: "_ _ _"
+    }
+  }
+}


### PR DESCRIPTION
This is required as, once the size is set once, it will not be properly
re-calculated when any other property connected to "updateImplicit" is
changed, as the offsetWidth/offsetHeight will always return the current
size.