### PR TITLE
QColor cleanup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ const path = require("path");
 
 const qtcoreSources = [
   "src/QmlWeb.js",
+  "src/polyfills/*.js",
   "src/qtbase/QObject.js",
   "src/qtbase/*.js",
   "src/modules/QtQml/Qt.js",

--- a/src/engine/QMLBoolean.js
+++ b/src/engine/QMLBoolean.js
@@ -1,0 +1,4 @@
+function QMLBoolean(val) {
+  return !!val;
+}
+QMLBoolean.plainType = true;

--- a/src/engine/QMLInteger.js
+++ b/src/engine/QMLInteger.js
@@ -1,3 +1,4 @@
 function QMLInteger(val) {
     return (val|0);
 }
+QMLInteger.plainType = true;

--- a/src/engine/QMLList.js
+++ b/src/engine/QMLList.js
@@ -8,3 +8,4 @@ function QMLList(meta) {
 
     return list;
 }
+QMLList.plainType = true;

--- a/src/engine/QMLNumber.js
+++ b/src/engine/QMLNumber.js
@@ -1,0 +1,4 @@
+function QMLNumber(val) {
+  return +val;
+}
+QMLNumber.plainType = true;

--- a/src/engine/QMLProperty.js
+++ b/src/engine/QMLProperty.js
@@ -97,6 +97,10 @@ QMLProperty.prototype.get = function() {
         this.changed.connect(evaluatingProperty, QMLProperty.prototype.update);
     }
 
+    if (this.val && this.val.$get) {
+      return this.val.$get();
+    }
+
     return this.val;
 }
 

--- a/src/engine/QMLProperty.js
+++ b/src/engine/QMLProperty.js
@@ -161,8 +161,10 @@ QMLProperty.prototype.set = function(newVal, reason, objectScope, componentScope
             this.val = construct({ object: newVal, parent: this.obj, context: componentScope });
     } else if (newVal instanceof Object || !newVal) {
         this.val = newVal;
-    } else {
+    } else if (constructors[this.type].plainType) {
         this.val = constructors[this.type](newVal);
+    } else {
+      this.val = new constructors[this.type](newVal);
     }
 
     if (this.val !== oldVal) {

--- a/src/engine/QMLString.js
+++ b/src/engine/QMLString.js
@@ -1,0 +1,4 @@
+function QMLString(val) {
+  return val + "";
+}
+QMLString.plainType = true;

--- a/src/engine/QMLVariant.js
+++ b/src/engine/QMLVariant.js
@@ -1,3 +1,4 @@
 function QMLVariant(val) {
     return val;
 }
+QMLVariant.plainType = true;

--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -10,17 +10,17 @@ var _executionContext = null;
 
 // All object constructors
 var constructors = {
-  'int': QMLInteger,
-  real: Number,
-  'double': Number,
-  string: String,
-  'bool': Boolean,
+  int: QMLInteger,
+  real: QMLNumber,
+  double: QMLNumber,
+  string: QMLString,
+  bool: QMLBoolean,
   list: QMLList,
   color: QColor,
-  'enum': Number,
-  url: String,
+  enum: QMLNumber,
+  url: QMLString,
   variant: QMLVariant,
-  'var': QMLVariant
+  var: QMLVariant
 };
 
 const modules = {

--- a/src/modules/QtQuick.Controls/Checkbox.js
+++ b/src/modules/QtQuick.Controls/Checkbox.js
@@ -40,7 +40,7 @@ registerQmlType({
         this.implicitWidth = label.offsetWidth > 0 ? label.offsetWidth + 4 : 0;
     });
     this.colorChanged.connect(this, function(newVal) {
-        span.style.color = QColor(newVal);
+        span.style.color = new QColor(newVal);
     });
 
     this.checkedChanged.connect(this, function(newVal) {

--- a/src/modules/QtQuick/Rectangle.js
+++ b/src/modules/QtQuick/Rectangle.js
@@ -26,13 +26,13 @@ registerQmlType({
     this.dom.appendChild(bg);
 
     this.colorChanged.connect(this, function(newVal) {
-        bg.style.backgroundColor = QColor(newVal);
+        bg.style.backgroundColor = new QColor(newVal);
     });
     this.radiusChanged.connect(this, function(newVal) {
         bg.style.borderRadius = newVal + 'px';
     });
     this.border.colorChanged.connect(this, function(newVal) {
-        bg.style.borderColor = QColor(newVal);
+        bg.style.borderColor = new QColor(newVal);
         if (bg.style.borderWidth == '0px') {
             bg.style.borderWidth = this.border.width + 'px';
         }

--- a/src/modules/QtQuick/Text.js
+++ b/src/modules/QtQuick/Text.js
@@ -33,7 +33,7 @@ registerQmlType({
     this.font   = new QMLFont(this);
 
     this.colorChanged.connect(this, function(newVal) {
-        fc.style.color = QColor(newVal);
+        fc.style.color = new QColor(newVal);
     });
     this.textChanged.connect(this, function(newVal) {
         fc.innerHTML = newVal;
@@ -90,7 +90,7 @@ registerQmlType({
         };
     });
     this.styleColorChanged.connect(this, function(newVal) {
-        newVal = QColor(newVal);
+        newVal = new QColor(newVal);
         switch (this.style) {
             case 0:
                 fc.style.textShadow = "none";

--- a/src/polyfills/WeakMap.js
+++ b/src/polyfills/WeakMap.js
@@ -1,0 +1,33 @@
+// This is a very simple and incomplete polyfill, but it serves our needs
+
+// NOTE: there is nothing weak about this polyfill, but that's what we get on
+// older browsers. It still helps us to use the real WeakMap on browsers that
+// support it (aka everything newer than IE10).
+
+// NOTE: new WeakMap(iterable) is not supported by this polyfill and has lower
+// browser support than just WeakMap, so if we ever need it, the feature
+// detection should be also improved.
+
+// NOTE: in this polyfill, keys are converted to strings. Keep that in mind.
+
+const WeakMap = global.WeakMap || global.Map || (() => {
+  const hasOwnProperty = Object.prototype.hasOwnProperty;
+  return class {
+    constructor(...args) {
+      if (args.length > 0) throw new Error("Not supported!");
+      this.$data = Object.create(null);
+    }
+    delete(key) {
+      delete this.$data[key];
+    }
+    get(key) {
+      return this.$data[key];
+    }
+    has(key) {
+      return hasOwnProperty.call(this.$data, key);
+    }
+    set(key, value) {
+      this.$data[key] = value;
+    }
+  };
+})();

--- a/src/qtbase/QColor.js
+++ b/src/qtbase/QColor.js
@@ -1,16 +1,21 @@
 // TODO complete implementation (with attributes `r`,`g` and `b`).
-function QColor(val) {
-  if (typeof val === "number") {
-    // we assume it is int value and must be converted to css hex with padding
-    // http://stackoverflow.com/questions/57803/how-to-convert-decimal-to-hex-in-javascript
-    val = "#" + (Math.round(val) + 0x1000000).toString(16).substr(-6).toUpperCase();
-  } else {
-    if(typeof val === "array" && val.length >= 3) {
-      // array like [r,g,b] where r,g,b are in 0..1 range
-      var m = 255;
-      val = "rgb(" + Math.round(m * val[0]) + "," + Math.round(m * val[1]) + "," + Math.round(m * val[2]) + ")";
+
+class QColor {
+  constructor(val) {
+    this.$value = "black";
+    if (val instanceof QColor) {
+      // Copy constructor
+      this.$value = val.$value;
+    } else if (typeof val === "string") {
+      this.$value = val.toLowerCase();
+    } else if (typeof val === "number") {
+      // we assume it is int value and must be converted to css hex with padding
+      val = (Math.round(val) + 0x1000000).toString(16).substr(-6);
+      this.$value = `#${val}`;
     }
   }
-  return val;
-};
-QColor.plainType = true;
+  toString() {
+    return this.$value;
+  }
+}
+QmlWeb.QColor = QColor;

--- a/src/qtbase/QColor.js
+++ b/src/qtbase/QColor.js
@@ -19,13 +19,13 @@ class QColor {
   }
   $get() {
     // Returns the same instance for all equivalent colors.
-    // Note that we can't return this instance, as it could be changed later.
-    // TODO: use a WeakMap with a polyfill to reduce the potential memory hit.
-    if (!QColor.colors[this.$value]) {
-      QColor.colors[this.$value] = new QColor(this.$value);
+    // NOTE: the returned value should not be changed using method calls, if
+    // those would be added in the future, the returned value should be wrapped.
+    if (!QColor.colors.has(this.$value)) {
+      QColor.colors.set(this.$value, this);
     }
-    return QColor.colors[this.$value];
+    return QColor.colors.get(this.$value);
   }
 }
-QColor.colors = {};
+QColor.colors = new WeakMap();
 QmlWeb.QColor = QColor;

--- a/src/qtbase/QColor.js
+++ b/src/qtbase/QColor.js
@@ -17,5 +17,15 @@ class QColor {
   toString() {
     return this.$value;
   }
+  $get() {
+    // Returns the same instance for all equivalent colors.
+    // Note that we can't return this instance, as it could be changed later.
+    // TODO: use a WeakMap with a polyfill to reduce the potential memory hit.
+    if (!QColor.colors[this.$value]) {
+      QColor.colors[this.$value] = new QColor(this.$value);
+    }
+    return QColor.colors[this.$value];
+  }
 }
+QColor.colors = {};
 QmlWeb.QColor = QColor;

--- a/src/qtbase/QColor.js
+++ b/src/qtbase/QColor.js
@@ -13,3 +13,4 @@ function QColor(val) {
   }
   return val;
 };
+QColor.plainType = true;

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -16,7 +16,7 @@ describe("QMLEngine.basic", function() {
     function() {
       var qml = load("CompletedOfDynamicObjects", this.div);
       expect(qml.children.length).toBe(1);
-      expect(qml.color).toBe("cyan");
+      expect(qml.color.toString()).toBe("cyan");
     }
   );
 

--- a/tests/QtBase/QColor.js
+++ b/tests/QtBase/QColor.js
@@ -1,0 +1,15 @@
+describe("QtBase.QColor", function() {
+  it("present", function() {
+    expect(!!QmlWeb && !!QmlWeb.QColor).toBe(true);
+  });
+
+  it("comparison", function() {
+    var color = new QmlWeb.QColor("#abcDEF");
+    expect(color.toString()).toBe("#abcdef");
+    // eslint-disable-next-line eqeqeq
+    expect(color == "#abcdef").toBe(true);
+    // eslint-disable-next-line eqeqeq
+    expect(color == "#abcDEF").toBe(false);
+    expect(color === "#abcdef").toBe(false);
+  });
+});

--- a/tests/QtQml/Types.js
+++ b/tests/QtQml/Types.js
@@ -1,0 +1,14 @@
+describe("QtQml.Types", function() {
+  setupDivElement();
+  var load = prefixedQmlLoader("QtQml/qml/Types");
+
+  it("Color", function() {
+    var qml = load("Color", this.div);
+    expect(qml.trueTests[0]).toBe(true);
+    expect(qml.trueTests[1]).toBe(true);
+    expect(qml.trueTests[2]).toBe(true);
+    expect(qml.falseTests[0]).toBe(false);
+    expect(qml.falseTests[1]).toBe(false);
+    expect(qml.falseTests[2]).toBe(false);
+  });
+});

--- a/tests/QtQml/qml/TypesColor.qml
+++ b/tests/QtQml/qml/TypesColor.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.0
+
+Item {
+  property color foo: "#abcDEF"
+  property color bar: "#abcdef"
+
+  property var trueTests: [
+    foo === bar,
+    foo == bar,
+    foo == "#abcdef"
+  ]
+  property var falseTests: [
+    foo === "#abcDEF",
+    foo == "#abcDEF",
+    foo === "#abcdef"
+  ]
+}


### PR DESCRIPTION
/cc @akreuzkamp @Plaristote @labsin 

The first commit is required to support initializing property types that require `new` usage (both «classes» and other prototype-based).

Creation of a `QColor` from an array was broken and not used.
Qt QML keeps the converted colors lower-case, testcase added.

`QColor` is not yet finished here, but it's already better than what we have now, and I think we should land this as is and continue improving it later.