### PR TITLE
Qml url

### DIFF
--- a/src/engine/QMLBinding.js
+++ b/src/engine/QMLBinding.js
@@ -28,8 +28,12 @@ class QMLBinding {
  * Compile binding. Afterwards you may call binding.eval to evaluate.
  */
   compile() {
-    this.eval = new Function("__executionObject", "__executionContext", `
+    this.eval = new Function("__executionObject", "__executionContext",
+      "__basePath", `
       QmlWeb.executionContext = __executionContext;
+      if (__basePath) {
+        QmlWeb.engine.$basePath = __basePath;
+      }
       with(QmlWeb) with(__executionContext) with(__executionObject) {
         ${this.isFunction ? "" : "return"} ${this.src}
         }

--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -478,7 +478,7 @@ class QMLEngine {
       return this.components[name];
     }
 
-    const file = `${this.$basePath}${name}.qml`;
+    const file = QmlWeb.engine.$resolvePath(`${name}.qml`);
     this.ensureFileIsLoadedInQrc(file);
     const tree = QmlWeb.convertToEngine(QmlWeb.qrc[file]);
     tree.$file = file;

--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -337,8 +337,6 @@ class QMLEngine {
         name = name.substr(0, name.length - 1);
       }
     }
-    // TODO if nameIsDir, we have also to add `name` to importPathList() for
-    // current component...
 
     let content = this.qmldirsContents[name];
     // check if we have already loaded that qmldir file

--- a/src/engine/QMLProperty.js
+++ b/src/engine/QMLProperty.js
@@ -73,8 +73,8 @@ class QMLProperty {
       if (!this.binding.eval) {
         this.binding.compile();
       }
-      this.$setVal(this.binding.eval(this.objectScope, this.componentScope),
-        this.componentScope);
+      this.$setVal(this.binding.eval(this.objectScope, this.componentScope,
+        this.componentScopeBasePath), this.componentScope);
     } catch (e) {
       console.log("QMLProperty.update binding error:",
         e,
@@ -136,6 +136,7 @@ class QMLProperty {
       this.binding = val;
       this.objectScope = objectScope;
       this.componentScope = componentScope;
+      this.componentScopeBasePath = componentScope.$basePath;
 
       if (QmlWeb.engine.operationState !== QmlWeb.QMLOperationState.Init) {
         if (!val.eval) {
@@ -144,7 +145,8 @@ class QMLProperty {
         try {
           QMLProperty.pushEvaluatingProperty(this);
           this.needsUpdate = false;
-          val = this.binding.eval(objectScope, componentScope);
+          val = this.binding.eval(objectScope, componentScope,
+            this.componentScopeBasePath);
         } finally {
           QMLProperty.popEvaluatingProperty();
         }

--- a/src/engine/QMLUrl.js
+++ b/src/engine/QMLUrl.js
@@ -1,0 +1,5 @@
+function QMLUrl(val) {
+  return QmlWeb.engine.$resolvePath(`${val}`);
+}
+QMLUrl.plainType = true;
+QmlWeb.qmlUrl = QMLUrl;

--- a/src/engine/import.js
+++ b/src/engine/import.js
@@ -94,16 +94,19 @@ function readQmlDir(url) {
   // Q1: when this happen?
   const qmldirFileUrl = url.length > 0 ? `${url}/qmldir` : "qmldir";
 
-  if (!QmlWeb.qrc.hasOwnProperty(qmldirFileUrl)) {
-    // loading url contents with skipping errors
-    QmlWeb.qrc[qmldirFileUrl] = getUrlContents(qmldirFileUrl, true);
+  const parsedUrl = QmlWeb.engine.$parseURI(qmldirFileUrl);
+
+  let qmldir;
+  if (parsedUrl.scheme === "qrc://") {
+    qmldir = QmlWeb.qrc[parsedUrl.path];
+  } else {
+    qmldir = getUrlContents(qmldirFileUrl, true) || undefined;
   }
 
-  const qmldir = QmlWeb.qrc[qmldirFileUrl];
   const internals = {};
   const externals = {};
 
-  if (qmldir === false) {
+  if (qmldir === undefined) {
     return false;
   }
 

--- a/src/engine/modules.js
+++ b/src/engine/modules.js
@@ -215,7 +215,6 @@ function callSuper(self, meta) {
  */
 function construct(meta) {
   let item;
-  let component;
 
   let constructors = perImportContextConstructors[meta.context.importContextId];
 
@@ -250,22 +249,20 @@ function construct(meta) {
      * for Qt.createComponent to have the correct context. */
     QmlWeb.executionContext = meta.context;
 
-    const Qt = QmlWeb.Qt;
+    let filePath;
     if (qdirInfo) {
-      // We have that component in some qmldir, load it from qmldir's url
-      component = Qt.createComponent(`@${qdirInfo.url}`);
+      filePath = qdirInfo.url;
+    } else
+    if (classComponents.length === 2) {
+      const qualified = QmlWeb.engine.qualifiedImportPath(
+        meta.context.importContextId, classComponents[0]
+      );
+      filePath = `${qualified}${classComponents[1]}.qml`;
     } else {
-      let filePath;
-      if (classComponents.length === 2) {
-        const qualified = QmlWeb.engine.qualifiedImportPath(
-          meta.context.importContextId, classComponents[0]
-        );
-        filePath = qualified + classComponents[1];
-      } else {
-        filePath = classComponents[0];
-      }
-      component = Qt.createComponent(`${filePath}.qml`);
+      filePath = `${classComponents[0]}.qml`;
     }
+
+    const component = QmlWeb.Qt.createComponent(filePath);
 
     if (!component) {
       throw new Error(`No constructor found for ${meta.object.$class}`);

--- a/src/engine/modules.js
+++ b/src/engine/modules.js
@@ -10,7 +10,7 @@ const modules = {
     list: QmlWeb.qmlList,
     color: QmlWeb.QColor,
     enum: QmlWeb.qmlNumber,
-    url: QmlWeb.qmlString,
+    url: QmlWeb.qmlUrl,
     variant: QmlWeb.qmlVariant,
     var: QmlWeb.qmlVariant
   }

--- a/src/engine/qrc.js
+++ b/src/engine/qrc.js
@@ -1,1 +1,30 @@
+/*
+
+QmlWeb.qrc is analogous to the Qt Resource System. It is expected to map a path
+within the resource system to the following pieces of data:
+
+1) For a QML Component, it is the return value of QmlWeb.parse
+2) For a JavaScript file, it is the return value of QmlWeb.jsparse
+2) For an image, it is any URL that an <img> tag can accept (e.g. a standard
+   URL to an image resource, or a "data:" URI). If there is no entry for a
+   given qrc image path, it will fall back to passing the path right through to
+   the DOM. This is mainly a convenience until support for images is added to
+   gulp-qmlweb.
+
+The "data-qml" tag on <body> can be set to a "qrc://" URL like
+"qrc:///root.qml" to use a pre-parsed "/root.qml" from QmlWeb.qrc.
+
+Since relative URLs are resolved relative to the URL of the containing
+component, any relative URL set within a file in the resource system will also
+resolve within the resource system. To access a Component, JavaScript or image
+file that is stored outside of the resources system from within the resource
+system, a full URL must be used (e.g. "http://www.example.com/images/foo.png").
+
+Vice-versa, in order to access a Component, JavaScript or image file that is
+stored within the resource system from outside of the resource system, a full
+"qrc://" URL must be used (e.g. "qrc:///images/foo.png").
+
+More details here: http://doc.qt.io/qt-5/qml-url.html
+
+*/
 QmlWeb.qrc = {};

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -47,17 +47,17 @@ class QMLComponent {
     }
   }
   finalizeImports($context) {
+    const engine = QmlWeb.engine;
     for (let i = 0; i < this.$jsImports.length; ++i) {
       const importDesc = this.$jsImports[i];
-      const src = QmlWeb.engine.$resolvePath(importDesc[1]);
-      let js;
+      const js = engine.loadJS(engine.$resolvePath(importDesc[1]));
 
-      if (typeof QmlWeb.qrc[src] !== "undefined") {
-        js = QmlWeb.qrc[src];
-      } else {
-        QmlWeb.loadParser();
-        js = QmlWeb.jsparse(QmlWeb.getUrlContents(src));
+      if (!js) {
+        console.log("Component.finalizeImports: failed to import JavaScript",
+          importDesc[1]);
+        continue;
       }
+
       if (importDesc[3] !== "") {
         $context[importDesc[3]] = {};
         QmlWeb.importJavascriptInContext(js, $context[importDesc[3]]);

--- a/src/modules/QtQml/Component.js
+++ b/src/modules/QtQml/Component.js
@@ -49,12 +49,9 @@ class QMLComponent {
   finalizeImports($context) {
     for (let i = 0; i < this.$jsImports.length; ++i) {
       const importDesc = this.$jsImports[i];
-      let src = importDesc[1];
+      const src = QmlWeb.engine.$resolvePath(importDesc[1]);
       let js;
 
-      if (typeof QmlWeb.engine.$basePath !== "undefined") {
-        src = QmlWeb.engine.$basePath + src;
-      }
       if (typeof QmlWeb.qrc[src] !== "undefined") {
         js = QmlWeb.qrc[src];
       } else {

--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -117,40 +117,7 @@ const Qt = {
 
   // Returns url resolved relative to the URL of the caller.
   // http://doc.qt.io/qt-5/qml-qtqml-qt.html#resolvedUrl-method
-  resolvedUrl: url => {
-    if (!url || !url.substr) {
-      // url is not a string object
-      return url;
-    }
-
-    const engine = QmlWeb.engine;
-
-    // Must check for cases: D:/, file://, http://, or slash at the beginning.
-    // This means the url is absolute => we have to skip processing
-    // (except removing dot segments).
-    if (url === "" || url.indexOf(":/") !== -1 || url.indexOf("/") === 0) {
-      return engine.removeDotSegments(url);
-    }
-
-    // we have $basePath variable placed in context of "current" document
-    // this is done in construct() function
-
-    // let's go to the callers and inspect their arguments
-    // The 2-nd argument of the callers we hope is context object
-    // e.g. see calling signature of bindings and signals
-
-    let detectedBasePath = "";
-    let currentCaller = Qt.resolvedUrl.caller;
-    let maxcount = 10;
-    while (maxcount-- > 0 && currentCaller) {
-      if (currentCaller.arguments[1] && currentCaller.arguments[1].$basePath) {
-        detectedBasePath = currentCaller.arguments[1].$basePath;
-        break;
-      }
-      currentCaller = currentCaller.caller;
-    }
-    return engine.removeDotSegments(detectedBasePath + url);
-  },
+  resolvedUrl: url => QmlWeb.qmlUrl(url),
 
   size: function size(width, height) {
     return new QmlWeb.QSizeF(width, height);

--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -36,7 +36,7 @@ const Qt = {
       resolvedName = name;
     }
 
-    let file = nameIsUrl ? resolvedName : engine.$basePath + resolvedName;
+    let file = nameIsUrl ? resolvedName : engine.$resolvePath(resolvedName);
     let src = QmlWeb.getUrlContents(file, true);
 
     // if failed to load, and provided name is not direct url,

--- a/src/modules/QtQuick/BorderImage.js
+++ b/src/modules/QtQuick/BorderImage.js
@@ -54,13 +54,14 @@ QmlWeb.registerQmlType({
     this.verticalTileModeChanged.connect(this, this.$updateBorder);
     this.smoothChanged.connect(this, this.$onSmoothChanged);
   }
-  $onSourceChanged(path) {
+  $onSourceChanged(source) {
     this.progress = 0;
     this.status = this.BorderImage.Loading;
     const style = this.impl.style;
-    style.OBorderImageSource = `url(${path})`;
-    style.borderImageSource = `url(${path})`;
-    this.$img.src = path;
+    const imageURL = QmlWeb.engine.$resolveImageURL(source);
+    style.OBorderImageSource = `url("${imageURL}")`;
+    style.borderImageSource = `url("${imageURL}")`;
+    this.$img.src = imageURL;
     if (this.$img.complete) {
       this.progress = 1;
       this.status = this.BorderImage.Ready;

--- a/src/modules/QtQuick/BorderImage.js
+++ b/src/modules/QtQuick/BorderImage.js
@@ -54,11 +54,10 @@ QmlWeb.registerQmlType({
     this.verticalTileModeChanged.connect(this, this.$updateBorder);
     this.smoothChanged.connect(this, this.$onSmoothChanged);
   }
-  $onSourceChanged() {
+  $onSourceChanged(path) {
     this.progress = 0;
     this.status = this.BorderImage.Loading;
     const style = this.impl.style;
-    const path = QmlWeb.engine.$resolvePath(this.source);
     style.OBorderImageSource = `url(${path})`;
     style.borderImageSource = `url(${path})`;
     this.$img.src = path;

--- a/src/modules/QtQuick/FontLoader.js
+++ b/src/modules/QtQuick/FontLoader.js
@@ -110,7 +110,7 @@ Refs: https://github.com/smnh/FontLoader.`);
     const fontName = `font_${Date.now().toString(36)}_${rand.toString(36)}`;
     this.$domStyle.innerHTML = `@font-face {
       font-family: ${fontName};
-      src: url('${QmlWeb.engine.$resolvePath(font_src)}');
+      src: url('${font_src}');
     }`;
     document.getElementsByTagName("head")[0].appendChild(this.$domStyle);
     this.$loadFont(fontName);

--- a/src/modules/QtQuick/Image.js
+++ b/src/modules/QtQuick/Image.js
@@ -95,9 +95,8 @@ QmlWeb.registerQmlType({
   $onSourceChanged(val) {
     this.progress = 0;
     this.status = this.Image.Loading;
-    const path = QmlWeb.engine.$resolvePath(val);
-    this.impl.style.backgroundImage = `url('${path}')`;
-    this.$img.src = path;
+    this.impl.style.backgroundImage = `url('${val}')`;
+    this.$img.src = val;
     if (this.$img.complete) {
       this.progress = 1;
       this.status = this.Image.Ready;

--- a/src/modules/QtQuick/Image.js
+++ b/src/modules/QtQuick/Image.js
@@ -92,11 +92,12 @@ QmlWeb.registerQmlType({
         break;
     }
   }
-  $onSourceChanged(val) {
+  $onSourceChanged(source) {
     this.progress = 0;
     this.status = this.Image.Loading;
-    this.impl.style.backgroundImage = `url('${val}')`;
-    this.$img.src = val;
+    const imageURL = QmlWeb.engine.$resolveImageURL(source);
+    this.impl.style.backgroundImage = `url("${imageURL}")`;
+    this.$img.src = imageURL;
     if (this.$img.complete) {
       this.progress = 1;
       this.status = this.Image.Ready;

--- a/src/modules/QtQuick/Loader.js
+++ b/src/modules/QtQuick/Loader.js
@@ -38,15 +38,11 @@ QmlWeb.registerQmlType({
       this.$onSourceComponentChanged(this.sourceComponent);
     }
   }
-  $onSourceChanged(newVal) {
-    // if (newVal == this.$sourceUrl && this.item !== undefined) return; // TODO
+  $onSourceChanged(fileName) {
+    // TODO
+    // if (fileName == this.$sourceUrl && this.item !== undefined) return;
     if (!this.active) return;
     this.$unload();
-
-    // TODO: we require ".qml" for now, that should be fixed
-    if (newVal.length <= 4) return;
-    if (newVal.substr(newVal.length - 4, 4) !== ".qml") return;
-    const fileName = newVal.substring(0, newVal.length - 4);
 
     const tree = QmlWeb.engine.loadComponent(fileName);
     const QMLComponent = QmlWeb.getConstructor("QtQml", "2.0", "Component");
@@ -59,7 +55,7 @@ QmlWeb.registerQmlType({
       qmlComponent.importContextId);
     const loadedComponent = this.$createComponentObject(qmlComponent, this);
     this.sourceComponent = loadedComponent;
-    this.$sourceUrl = newVal;
+    this.$sourceUrl = fileName;
   }
   $onSourceComponentChanged(newItem) {
     if (!this.active) return;

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -22,11 +22,15 @@ describe("QMLEngine.basic", function() {
 
   it("Qt.resolvedUrl", function() {
     var qml = load("ResolvedUrl", this.div);
-    expect(qml.outer).toBe("/base/tests/");
+    /* Get the base address of the URL */
+    const a = document.createElement("a");
+    a.href = "/";
+    expect(qml.outer).toBe(a.href + "base/tests/");
     expect(qml.current).toBe(qml.outer + "QMLEngine/qml/");
     expect(qml.inner1).toBe(qml.current + "foo/bar");
     expect(qml.inner2).toBe(qml.current + "foo/bar/");
     expect(qml.inner3).toBe(qml.current + "foo/foo/lol/");
+    expect(qml.absolute).toBe(a.href + "foo/bar");
     expect(qml.full).toBe("http://example.com/bar");
   });
 

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -91,4 +91,24 @@ describe("QMLEngine.properties", function() {
     var qml = load("ChangedExpressionSignal", this.div);
     expect(qml.counter).toBe(1);
   });
+
+  it("Url", function() {
+    var qml = load("Url", this.div);
+    expect(qml.localBindingSimple).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localBindingSimple.png");
+    expect(qml.localBinding).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localBinding.png");
+    expect(qml.localSet).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localSet.png");
+    expect(qml.remoteBindingSimple).toBe(
+      QmlWeb.engine.$basePath + "remoteBindingSimple.png");
+    expect(qml.remoteBinding).toBe(
+      QmlWeb.engine.$basePath + "remoteBinding.png");
+    expect(qml.remoteSet).toBe(QmlWeb.engine.$basePath + "remoteSet.png");
+    expect(qml.http).toBe("http://http-url");
+    /* Get the base address of the URL */
+    const a = document.createElement("a");
+    a.href = "/";
+    expect(qml.absolute).toBe(a.href + "absolute-url");
+  });
 });

--- a/tests/QMLEngine/qml/BasicResolvedUrl.qml
+++ b/tests/QMLEngine/qml/BasicResolvedUrl.qml
@@ -4,7 +4,8 @@ Item {
   property var current: Qt.resolvedUrl('.')
   property var inner1: Qt.resolvedUrl('foo/bar')
   property var inner2: Qt.resolvedUrl('foo/bar/')
-  property var inner3: Qt.resolvedUrl('foo/bar/../foo/bar/./../lol/x../..s/../..')
+  property var inner3: Qt.resolvedUrl('foo//bar/../foo////bar/./../lol/x../..s/../..')
   property var outer: Qt.resolvedUrl('../..')
   property var full: Qt.resolvedUrl('http://example.com/bar')
+  property var absolute: Qt.resolvedUrl('/foo/bar')
 }

--- a/tests/QMLEngine/qml/PropertiesUrl.qml
+++ b/tests/QMLEngine/qml/PropertiesUrl.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.0
+import "PropertiesUrlDir"
+
+Item {
+  property alias localBindingSimple: properties_url_import.localBindingSimple
+  property alias localBinding: properties_url_import.localBinding
+  property alias localSet: properties_url_import.localSet
+  property alias remoteBindingSimple: properties_url_import.remoteBindingSimple
+  property alias remoteBinding: properties_url_import.remoteBinding
+  property alias remoteSet: properties_url_import.remoteSet
+  property url http: "http://http-url"
+  property url absolute: "/absolute-url"
+  PropertiesUrlImport {
+    id: properties_url_import
+    remoteBindingSimple: "remoteBindingSimple.png"
+    remoteBinding: "remote" + "Binding.png"
+    Component.onCompleted: {
+      properties_url_import.remoteSet = "remoteSet.png"
+    }
+  }
+}

--- a/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImport.qml
+++ b/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImport.qml
@@ -1,0 +1,13 @@
+import QtQuick 2.0
+
+Item {
+  property url localBindingSimple: "localBindingSimple.png"
+  property url localBinding: "local" + "Binding.png"
+  property url localSet
+  property url remoteBindingSimple
+  property url remoteBinding
+  property url remoteSet
+  Component.onCompleted: {
+    localSet = "localSet.png"
+  }
+}

--- a/tests/QMLEngine/qrc.js
+++ b/tests/QMLEngine/qrc.js
@@ -1,0 +1,134 @@
+describe("QMLEngine.qrc", function() {
+  it("present", function() {
+    expect(!!QmlWeb && QmlWeb.qrc !== undefined).toBe(true);
+  });
+
+  setupDivElement();
+
+  /* Put some stuff into QmlWeb.qrc, this is what gulp-qmlweb does */
+  var qrc_files = [
+    ["/Basic.qml",
+      "import QtQuick 2.0\n Item { property int value: 42 }"
+    ],
+    ["/SomeDir/SomeFile.qml",
+      "import QtQuick 2.0\n Item { property int value: 43 }"
+    ],
+    ["/QMLImportRelative.qml",
+      'import QtQuick 2.0\n import "SomeDir"\n SomeFile { }'
+    ],
+    ["/QMLImportRelativeQualified.qml",
+      'import QtQuick 2.0\n import "SomeDir" as SomeDir\n SomeDir.SomeFile { }'
+    ],
+    ["/SomeDir/QMLImportRelativeDots.qml",
+      'import QtQuick 2.0\n import "../SomeDir/../SomeDir/./"\n SomeFile { }'
+    ],
+    ["/SomeDir/QMLImportRelativeDotsQualified.qml",
+      'import QtQuick 2.0\n import "../SomeDir/../SomeDir/./" as SomeDir\n' +
+      "SomeDir.SomeFile { }"
+    ],
+    ["/QMLImportAbsolute.qml",
+      'import QtQuick 2.0\n import "/SomeDir"\n SomeFile { }'
+    ],
+    ["/QMLImportAbsoluteQualified.qml",
+      'import QtQuick 2.0\n import "/SomeDir" as SomeDir\n SomeDir.SomeFile { }'
+    ],
+    ["/SomeDir/QMLImportLocal.qml",
+      "import QtQuick 2.0\n SomeFile { }"
+    ],
+    ["/JavaScriptImport.qml",
+      'import QtQuick 2.0\n import "JavaScript.js" as JSModule\n' +
+      "Item { property int value: JSModule.value }"
+    ],
+    ["/JavaScript.js",
+      "var value = 44;"
+    ],
+    ["/LoaderRelative.qml",
+      'import QtQuick 2.0\n Loader { source: "SomeDir/SomeFile.qml" }'
+    ],
+    ["/LoaderAbsolute.qml",
+      'import QtQuick 2.0\n Loader { source: "/SomeDir/SomeFile.qml" }'
+    ],
+    ["/SomeDir/LoaderRelativeDots.qml",
+      'import QtQuick 2.0\n Loader { source: "../SomeDir/./SomeFile.qml" }'
+    ]
+  ];
+
+  QmlWeb.loadParser();
+
+  for (var i in qrc_files) {
+    const path = qrc_files[i][0];
+    const str = qrc_files[i][1];
+
+    var data;
+    if (path.match(/\.qml$/) !== null) {
+      data = QmlWeb.parse(str, QmlWeb.parse.QMLDocument);
+    } else if (path.match(/\.js$/) !== null) {
+      data = QmlWeb.jsparse(str);
+    } else {
+      data = str;
+    }
+
+    QmlWeb.qrc[path] = data;
+  }
+
+  it("basic", function() {
+    var qml = loadQmlFile("qrc:///Basic.qml", this.div);
+    expect(qml.value).toBe(42);
+  });
+
+  it("QML import relative", function() {
+    var qml = loadQmlFile("qrc:///QMLImportRelative.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import relative qualified", function() {
+    var qml = loadQmlFile("qrc:///QMLImportRelativeQualified.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import relative dots", function() {
+    var qml = loadQmlFile("qrc:///SomeDir/QMLImportRelativeDots.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import relative dots qualified", function() {
+    var qml = loadQmlFile("qrc:///SomeDir/QMLImportRelativeDotsQualified.qml",
+      this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import absolute", function() {
+    var qml = loadQmlFile("qrc:///QMLImportAbsolute.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import absolute qualified", function() {
+    var qml = loadQmlFile("qrc:///QMLImportAbsoluteQualified.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("QML import local", function() {
+    var qml = loadQmlFile("qrc:///SomeDir/QMLImportLocal.qml", this.div);
+    expect(qml.value).toBe(43);
+  });
+
+  it("JavaScript import", function() {
+    var qml = loadQmlFile("qrc:///JavaScriptImport.qml", this.div);
+    expect(qml.value).toBe(44);
+  });
+
+  it("Loader relative", function() {
+    var qml = loadQmlFile("qrc:///LoaderRelative.qml", this.div);
+    expect(qml.item.value).toBe(43);
+  });
+
+  it("Loader absolute", function() {
+    var qml = loadQmlFile("qrc:///LoaderAbsolute.qml", this.div);
+    expect(qml.item.value).toBe(43);
+  });
+
+  it("Loader relative dots", function() {
+    var qml = loadQmlFile("qrc:///SomeDir/LoaderRelativeDots.qml", this.div);
+    expect(qml.item.value).toBe(43);
+  });
+});


### PR DESCRIPTION
This depends on #313 for a couple of the tests to succeed.  Without it, the result of non-simple bindings aren't even passed to the QMLUrl constructor.

I think the logic of `$rootBasePath` makes sense, but I'm not 100% sold on it. It currently makes any absolute URLs within the context of QML relative to the root QML item's path, which is not necessarily the same as the webpage's root URL. It makes it easier to move a qmlweb project with absolute URLs around within a webpage's directory structure, but it makes it impossible to reference URLs outside of the qmlweb sandbox, without a full `http://...`.

Maybe there shouldn't be a concept of `$rootBasePath` and it's just up to the webpage admin to setup URL symlinks and the like accordingly.