### PR TITLE
QtQuick/Item: Only set "parent" property for Item-inherited items

### DIFF
--- a/src/modules/QtQuick/Item.js
+++ b/src/modules/QtQuick/Item.js
@@ -186,11 +186,10 @@ registerQmlType({
     this.$updateVGeometry(newParent, oldParent, propName);
   }
   $onDataChanged(newData) {
+    const QMLItem = QmlWeb.getConstructor("QtQuick", "2.0", "Item");
     for (const i in newData) {
       const child = newData[i];
-      if (child.hasOwnProperty("parent")) {
-        // Seems to be an Item.
-        // TODO: Use real inheritance and ask using instanceof.
+      if (child instanceof QMLItem) {
         child.parent = this; // This will also add it to children.
       } else {
         this.resources.push(child);


### PR DESCRIPTION
With the change to giving Timer a read-only "parent" property, it was
no longer added to resources (and logged out exceptions).