### PR TITLE
Signal: add QueuedConnection support

### DIFF
--- a/tests/QtBase/Signal.js
+++ b/tests/QtBase/Signal.js
@@ -53,4 +53,28 @@ describe("QtBase.Signal", function() {
     signal.execute();
     expect(result).toBe(24);
   });
+
+  it("QueuedConnection", function(done) {
+    var signal = new QmlWeb.Signal();
+    var result = 0;
+    var test1 = function() {
+      result += 1;
+    };
+    var test2 = function() {
+      result += 10;
+    };
+    signal.connect(test1, QmlWeb.Signal.QueuedConnection);
+    expect(result).toBe(0);
+    signal.execute();
+    expect(result).toBe(0);
+    signal.connect(test2, QmlWeb.Signal.QueuedConnection);
+    signal.execute();
+    expect(result).toBe(0);
+    signal.execute();
+    expect(result).toBe(0);
+    setTimeout(function() {
+      expect(result).toBe(23);
+      done();
+    }, 10);
+  });
 });


### PR DESCRIPTION
This implements `QueuedConnection` support, where actual execution of the signal handler is delayed until the control returns to the event loop.

/cc @akreuzkamp 

I am not sure if I did the correct thing with `QmlWeb.QMLProperty.pushEvalStack()` and `QmlWeb.QMLProperty.popEvalStack()`, so /cc @pavelvasev and @stephenmdangelo for that.