### PR TITLE
qml: don't override default constructors in loadImports()

### DIFF
--- a/src/engine/qml.js
+++ b/src/engine/qml.js
@@ -142,7 +142,7 @@ const perImportContextConstructors = {};
 
 function loadImports(self, imports) {
   const mergeObjects = QmlWeb.helpers.mergeObjects;
-  constructors = mergeObjects(modules.Main);
+  let constructors = mergeObjects(modules.Main);
   if (imports.filter(row => row[1] === 'QtQml').length === 0 &&
       imports.filter(row => row[1] === 'QtQuick').length === 1) {
     imports.push(['qmlimport', 'QtQml', 2, '', true]);


### PR DESCRIPTION
I am currently reviewing and cleaning up the last file left — `qml.js`, and that process was stuck on that line.

This PR is only about the actual change, one we figure out what should be done there I will clean up the code accordingly, perhaps even removing some unneeded data structures. This is most likely wrong, I am not sure what's going on here, this is why I am asking =).

What `loadImports()` does now is that it both overrides the default `constructors` _and_ saves those in `perImportContextConstructors` for further use in `construct`. Perhaps that's a mistake?

`loadImports` resets the scoped (global-ish) `constructors` atm on each `loadImports()` call.

Note that `registerGlobalQmlType()` (and `registerQmlType` with `global` option) add new elements to `constructors` — those are not removed by `loadImports()`, though, that's probably as expected.

The complete list of places where that `constructors` object is used:
- https://github.com/qmlweb/qmlweb/blob/master/src/engine/QMLEngine.js#L58-L63
- https://github.com/qmlweb/qmlweb/blob/master/src/engine/QMLProperty.js#L23-L56
- https://github.com/qmlweb/qmlweb/blob/master/src/modules/QtQml/Component.js#L14

So this is basically a question of what exactly should be used in those places? Perhaps those lines should be changed to include something else than this `constructors` object?

Note: I could be missing something, and it might in fact be as designed.

/cc @akreuzkamp @stephenmdangelo @pavelvasev 
