### PR TITLE
QMLEngine: Fix loadFile to work with subdirectories

### DIFF
--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -142,7 +142,7 @@ class QMLEngine {
   }
 
   extractFileName(file) {
-    return file.split('\\').pop().split('/').pop();
+    return file.split(/[\/\\]/).pop();
   }
 
   // Load file, parse and construct (.qml or .qml.js)

--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -141,6 +141,10 @@ class QMLEngine {
     return basePath.join("/");
   }
 
+  extractFileName(file) {
+    return file.split('\\').pop().split('/').pop();
+  }
+
   // Load file, parse and construct (.qml or .qml.js)
   loadFile(file, parentComponent = null) {
     // Create an anchor element to get the absolute path from the DOM
@@ -149,7 +153,7 @@ class QMLEngine {
     }
     this.$basePathA.href = this.extractBasePath(file);
     this.$basePath = this.$basePathA.href;
-    const tree = this.loadComponent(this.$resolvePath(file));
+    const tree = this.loadComponent(this.$resolvePath(this.extractFileName(file)));
     return this.loadQMLTree(tree, parentComponent, file);
   }
 

--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -153,7 +153,8 @@ class QMLEngine {
     }
     this.$basePathA.href = this.extractBasePath(file);
     this.$basePath = this.$basePathA.href;
-    const tree = this.loadComponent(this.$resolvePath(this.extractFileName(file)));
+    const fileName = this.extractFileName(file);
+    const tree = this.loadComponent(this.$resolvePath(fileName));
     return this.loadQMLTree(tree, parentComponent, file);
   }
 


### PR DESCRIPTION
Should fix the problem of autoloading for example "./qml/index.qml" resulting in trying to load ./qml/qml/index.qml" instead.