### PR TITLE
engine/properties: Set engine $basePath back after evaluating a slot

### DIFF
--- a/src/engine/properties.js
+++ b/src/engine/properties.js
@@ -226,11 +226,16 @@ function connectSignal(item, signalName, value, objectScope, componentScope) {
     for (const j in item[signalName].parameters) {
       params.push(item[signalName].parameters[j].name);
     }
+    // Wrap value.src in IIFE in case it includes a "return"
     value.src = `(
       function(${params.join(", ")}) {
         QmlWeb.executionContext = __executionContext;
+        QmlWeb.engine.$oldBasePath = QmlWeb.engine.$basePath;
         QmlWeb.engine.$basePath = "${componentScope.$basePath}";
-        ${value.src}
+        (function() {
+          ${value.src}
+        })();
+        QmlWeb.engine.$basePath = QmlWeb.engine.$oldBasePath;
       }
     )`;
     value.isFunction = false;

--- a/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImport.qml
+++ b/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImport.qml
@@ -10,4 +10,17 @@ Item {
   Component.onCompleted: {
     localSet = "localSet.png"
   }
+  /* These are required as they force some slots to run in this context when
+   * things are done in PropertiesUrl. This tests that running slots in this
+   * context doesn't have any unintended consequences. The "return" statements
+   * are to ensure that slot handling continues after a return. */
+  onRemoteSetChanged: {
+      return
+  }
+  onRemoteBindingSimpleChanged: {
+      return
+  }
+  onRemoteBindingChanged: {
+      return
+  }
 }


### PR DESCRIPTION
Slots can be invoked as the result of a property changing, and they
shouldn't leave the engine $basePath in a bad state.