### PR TITLE
modules/Text: Properly initialize wrapMode

### DIFF
--- a/src/modules/QtQuick/Text.js
+++ b/src/modules/QtQuick/Text.js
@@ -49,9 +49,7 @@ QmlWeb.registerQmlType({
     this.color = "black";
     this.text = "";
 
-    this.textChanged.connect(this, this.$onTextChanged);
     this.widthChanged.connect(this, this.$onWidthChanged);
-    this.wrapModeChanged.connect(this, this.$onWrapModeChanged);
 
     this.font.boldChanged.connect(this, this.$onFontChanged);
     this.font.weightChanged.connect(this, this.$onFontChanged);
@@ -127,6 +125,7 @@ QmlWeb.registerQmlType({
   }
   Component$onCompleted() {
     this.$updateImplicit();
+    this.$onWrapModeChanged(this.wrapMode);
   }
   $updateImplicit() {
     if (!this.text || !this.dom) {

--- a/tests/QtQuick/Text.js
+++ b/tests/QtQuick/Text.js
@@ -6,5 +6,10 @@ describe("QtQuick.Text", function() {
     var qml = load("ImplicitSize", this.div);
     expect(qml.text_item.width).toBeGreaterThan(0);
   });
+
+  it("default wrap mode", function() {
+    var qml = load("WrapMode", this.div);
+    expect(qml.dom.children[0].style.whiteSpace).toBe("pre");
+  });
 });
 

--- a/tests/QtQuick/qml/TextWrapMode.qml
+++ b/tests/QtQuick/qml/TextWrapMode.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Text {
+  text: "foo"
+}


### PR DESCRIPTION
Call $onWrapModeChanged to initialize CSS properties for the default
wrapMode of NoWrap.

Also removed double connections to text, wrapMode changed.
