### PR TITLE
Disconnect all signals on delete

### DIFF
--- a/src/qtbase/QObject.js
+++ b/src/qtbase/QObject.js
@@ -10,6 +10,7 @@ class QObject {
     // List of things to tidy up when deleting this object.
     this.$tidyupList = [];
     this.$properties = {};
+    this.$signals = [];
 
     this.objectId = objectIds++;
   }
@@ -46,6 +47,12 @@ class QObject {
     // 1) parent will be notified and erase object from it's children.
     // 2) DOM node will be removed.
     this.parent = undefined;
+
+    // Disconnect any slots connected to any of our signals. Do this after
+    // clearing the parent, as that relies on parentChanged being handled.
+    for (const i in this.$signals) {
+      this.$signals[i].disconnect();
+    }
   }
 
   // must have a `destroy` method

--- a/src/qtbase/Signal.js
+++ b/src/qtbase/Signal.js
@@ -58,12 +58,14 @@ class Signal {
     // type meaning:
     //  1 = function, 2 = string
     //  3 = object with string method,  4 = object with function
+    // No args means disconnect everything connected to this signal
     const callType = args.length === 1
       ? args[0] instanceof Function ? 1 : 2
       : typeof args[1] === "string" || args[1] instanceof String ? 3 : 4;
     for (let i = 0; i < this.connectedSlots.length; i++) {
       const { slot, thisObj } = this.connectedSlots[i];
       if (
+        args.length === 0 ||
         callType === 1 && slot === args[0] ||
         callType === 2 && thisObj === args[0] ||
         callType === 3 && thisObj === args[0] && slot === args[0][args[1]] ||
@@ -71,7 +73,9 @@ class Signal {
       ) {
         if (thisObj) {
           const index = thisObj.$tidyupList.indexOf(this.signal);
-          thisObj.$tidyupList.splice(index, 1);
+          if (index >= 0) {
+            thisObj.$tidyupList.splice(index, 1);
+          }
         }
         this.connectedSlots.splice(i, 1);
         // We have removed an item from the list so the indexes shifted one

--- a/src/qtbase/Signal.js
+++ b/src/qtbase/Signal.js
@@ -9,6 +9,11 @@ class Signal {
     this.signal.connect = this.connect.bind(this);
     this.signal.disconnect = this.disconnect.bind(this);
     this.signal.isConnected = this.isConnected.bind(this);
+
+    // XXX Fix Keys that don't have an obj for the signal
+    if (this.obj && this.obj.$signals !== undefined) {
+      this.obj.$signals.push(this.signal);
+    }
   }
   execute(...args) {
     QmlWeb.QMLProperty.pushEvalStack();

--- a/tests/QMLEngine/basic.js
+++ b/tests/QMLEngine/basic.js
@@ -46,6 +46,16 @@ describe("QMLEngine.basic", function() {
     expect(qml.log).toBe("i12i2");
   });
 
+  it("signal disconnect when QObject deleted", function() {
+    var qml = load("SignalDisconnectOnDelete", this.div);
+    var child = qml.create_object();
+    expect(qml.$tidyupList.indexOf(child.colorChanged)).toBe(-1);
+    child.colorChanged.connect(qml, qml.foo);
+    expect(qml.$tidyupList.indexOf(child.colorChanged)).not.toBeLessThan(0);
+    child.destroy();
+    expect(qml.$tidyupList.indexOf(child.colorChanged)).toBe(-1);
+  });
+
   it("createObject", function() {
     var qml = load("CreateObject", this.div);
     expect(qml.children.length).toBe(1);

--- a/tests/QMLEngine/qml/BasicSignalDisconnectOnDelete.qml
+++ b/tests/QMLEngine/qml/BasicSignalDisconnectOnDelete.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.2
+
+Item {
+  id: item
+  property variant child
+
+  function foo() {
+      console.log("colour changed");
+  }
+
+  Item {
+      id: some_child
+  }
+
+  function create_object() {
+    return Qt.createQmlObject(
+      "import QtQuick 2.2\nRectangle { color: 'green'; width: 320; height: 32; }",
+      some_child,
+      "inlinecode1"
+    );
+  }
+}


### PR DESCRIPTION
I discovered this when the delegates of a Repeater are parented to a Column, as Positioner connects to various signals of it's children, and the Positioner is not the QObject parent of the delegates, but this could happen any time a signal on QObjectA is connected to a slot on QObjectB if QObjectB is not the parent of QObjectA.

I am open to suggestions on this fix. It seems overkill to add `$signals` as another list of things to cleanup (maybe `$tidyupList` could contain Objects with some extra information rather than just relying on the item type).

Also, there are some Signals that don't have an associated `obj` (like all of the `Keys.*` Signals). I'm going to test some more stuff with that, but I feel like a manual `item.Keys.pressed.connect(...)` could also result in a similar leak.

And the test is pretty internal and contrived, but I have confirmed it with the Chrome memory profiler.
