### PR TITLE
properties/connectSignal: restore QmlEngine.$basePath on slot exception

### DIFF
--- a/src/engine/properties.js
+++ b/src/engine/properties.js
@@ -232,10 +232,13 @@ function connectSignal(item, signalName, value, objectScope, componentScope) {
         QmlWeb.executionContext = __executionContext;
         QmlWeb.engine.$oldBasePath = QmlWeb.engine.$basePath;
         QmlWeb.engine.$basePath = "${componentScope.$basePath}";
-        (function() {
-          ${value.src}
-        })();
-        QmlWeb.engine.$basePath = QmlWeb.engine.$oldBasePath;
+        try {
+          (function() {
+            ${value.src}
+          })();
+        } finally {
+          QmlWeb.engine.$basePath = QmlWeb.engine.$oldBasePath;
+        }
       }
     )`;
     value.isFunction = false;

--- a/tests/QMLEngine/properties.js
+++ b/tests/QMLEngine/properties.js
@@ -111,4 +111,19 @@ describe("QMLEngine.properties", function() {
     a.href = "/";
     expect(qml.absolute).toBe(a.href + "absolute-url");
   });
+
+  it("Url exception safe", function() {
+    var qml = load("UrlExceptionSafe", this.div);
+    expect(qml.localBindingSimple).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localBindingSimple.png");
+    expect(qml.localBinding).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localBinding.png");
+    expect(qml.localSet).toBe(
+      QmlWeb.engine.$basePath + "PropertiesUrlDir/localSet.png");
+    expect(qml.remoteBindingSimple).toBe(
+      QmlWeb.engine.$basePath + "remoteBindingSimple.png");
+    expect(qml.remoteBinding).toBe(
+      QmlWeb.engine.$basePath + "remoteBinding.png");
+    expect(qml.remoteSet).toBe(QmlWeb.engine.$basePath + "remoteSet.png");
+  });
 });

--- a/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImportWithExceptions.qml
+++ b/tests/QMLEngine/qml/PropertiesUrlDir/PropertiesUrlImportWithExceptions.qml
@@ -1,0 +1,35 @@
+import QtQuick 2.0
+
+Item {
+  property url localBindingSimple: "localBindingSimple.png"
+  property url localBinding: "local" + "Binding.png"
+  property url localSet
+  property url remoteBindingSimple
+  property url remoteBinding
+  property url remoteSet
+  Component.onCompleted: {
+    localSet = "localSet.png"
+  }
+  /* These are required as they force some slots to run in this context when
+   * things are done in PropertiesUrlExceptionSafe. This tests that running
+   * slots that throw an exception in this context doesn't have any unintended
+   * consequences. */
+  onLocalSetChanged: {
+      throw "Some Exception"
+  }
+  onLocalBindingSimpleChanged: {
+      throw "Some Exception"
+  }
+  onLocalBindingChanged: {
+      throw "Some Exception"
+  }
+  onRemoteSetChanged: {
+      throw "Some Exception"
+  }
+  onRemoteBindingSimpleChanged: {
+      throw "Some Exception"
+  }
+  onRemoteBindingChanged: {
+      throw "Some Exception"
+  }
+}

--- a/tests/QMLEngine/qml/PropertiesUrlExceptionSafe.qml
+++ b/tests/QMLEngine/qml/PropertiesUrlExceptionSafe.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.0
+import "PropertiesUrlDir"
+
+Item {
+  property alias localBindingSimple: properties_url_import.localBindingSimple
+  property alias localBinding: properties_url_import.localBinding
+  property alias localSet: properties_url_import.localSet
+  property alias remoteBindingSimple: properties_url_import.remoteBindingSimple
+  property alias remoteBinding: properties_url_import.remoteBinding
+  property alias remoteSet: properties_url_import.remoteSet
+  PropertiesUrlImportWithExceptions {
+    id: properties_url_import
+    remoteBindingSimple: "remoteBindingSimple.png"
+    remoteBinding: "remote" + "Binding.png"
+    Component.onCompleted: {
+      properties_url_import.remoteSet = "remoteSet.png"
+    }
+    /* These are required as they force some slots to run in this context when
+     * things are done in PropertiesUrlExceptionSafe. This tests that running
+     * slots that throw an exception in this context doesn't have any unintended
+     * consequences. */
+    onLocalSetChanged: {
+      throw "Some Exception"
+    }
+    onLocalBindingSimpleChanged: {
+      throw "Some Exception"
+    }
+    onLocalBindingChanged: {
+      throw "Some Exception"
+    }
+    onRemoteSetChanged: {
+      throw "Some Exception"
+    }
+    onRemoteBindingSimpleChanged: {
+      throw "Some Exception"
+    }
+    onRemoteBindingChanged: {
+      throw "Some Exception"
+    }
+  }
+}


### PR DESCRIPTION
Previously, the $basePath could end up in a bad state if a slot threw an
exception.
