### PR TITLE
engine/properties: Support properties starting with "on"

### DIFF
--- a/src/engine/properties.js
+++ b/src/engine/properties.js
@@ -74,15 +74,17 @@ function applyProperties(metaObject, item, objectScopeIn, componentScope) {
     }
 
     // slots
-    if (i.indexOf("on") === 0 && i[2].toUpperCase() === i[2]) {
+    if (i.indexOf("on") === 0 && i.length > 2 && /[A-Z]/.test(i[2])) {
       const signalName = i[2].toLowerCase() + i.slice(3);
       if (!connectSignal(item, signalName, value, objectScope,
                                                   componentScope)) {
         if (item.$setCustomSlot) {
           item.$setCustomSlot(signalName, value, objectScope, componentScope);
+          continue;
         }
+      } else {
+        continue;
       }
-      continue;
     }
 
     if (value instanceof Object) {


### PR DESCRIPTION
Fixes an exception for properties named "on"

No longer check for a signal for properties like "on_" (since
"_".toUpperCase() === "_")

If no signal is found, try to find a property with the name
(for properties like "onProp" that match the RegExp).