### PR TITLE
[Breaking] Wrap all root elements

### DIFF
--- a/examples/embed.html
+++ b/examples/embed.html
@@ -4,7 +4,7 @@
     <title>QML Embed Example</title>
     <style>
       #embed {
-        width: 400px;
+        width: 50%;
         height: 300px;
         border: 10px dotted red;
       }

--- a/src/modules/QtQuick/Item.js
+++ b/src/modules/QtQuick/Item.js
@@ -38,21 +38,10 @@ QmlWeb.registerQmlType({
   constructor(meta) {
     QmlWeb.callSuper(this, meta);
 
-    if (this.$parent === null) { // This is the root element. Initialize it.
-      this.dom = QmlWeb.engine.rootElement || document.body;
-      this.dom.innerHTML = "";
-      // Needed to make absolute positioning work
-      this.dom.style.position = "relative";
-      this.dom.style.top = "0";
-      this.dom.style.left = "0";
-      // No QML stuff should stand out the root element
-      this.dom.style.overflow = "hidden";
-    } else {
-      if (!this.dom) { // Create a dom element for this item.
-        this.dom = document.createElement(meta.tagName || "div");
-      }
-      this.dom.style.position = "absolute";
+    if (!this.dom) { // Create a dom element for this item.
+      this.dom = document.createElement(meta.tagName || "div");
     }
+    this.dom.style.position = "absolute";
     this.dom.style.pointerEvents = "none";
     // In case the class is qualified, only use the last part for the css class
     // name.
@@ -141,38 +130,6 @@ QmlWeb.registerQmlType({
     this.$revertActions = [];
     this.css.left = `${this.x}px`;
     this.css.top = `${this.y}px`;
-
-    // Init size of root element
-    if (this.$parent === null) {
-      if (!QmlWeb.engine.rootElement) {
-        // Case 1: Qml scene is placed in body tag
-
-        // event handling by addEventListener is probably better than setting
-        // window.onresize
-        const updateQmlGeometry = () => {
-          this.implicitHeight = window.innerHeight;
-          this.implicitWidth = window.innerWidth;
-        };
-        window.addEventListener("resize", updateQmlGeometry);
-        updateQmlGeometry();
-      } else {
-        // Case 2: Qml scene is placed in some element tag
-
-        // we have to call `this.implicitHeight =` and `this.implicitWidth =`
-        // each time the rootElement changes it's geometry
-        // to reposition child elements of qml scene
-
-        // it is good to have this as named method of dom element, so we can
-        // call it from outside too, whenever element changes it's geometry
-        // (not only on window resize)
-        this.dom.updateQmlGeometry = () => {
-          this.implicitHeight = this.dom.offsetHeight;
-          this.implicitWidth = this.dom.offsetWidth;
-        };
-        window.addEventListener("resize", this.dom.updateQmlGeometry);
-        this.dom.updateQmlGeometry();
-      }
-    }
   }
   $onParentChanged_(newParent, oldParent, propName) {
     if (oldParent) {

--- a/tests/Initialize/runner.js
+++ b/tests/Initialize/runner.js
@@ -92,8 +92,9 @@ function testModule(module, element, imports, options) {
       var src = imports + element + " { }\n";
       var qml = loadQml(src, this.div);
       if (options.dom) {
-        expect(this.div.className).toBe(element);
-        expect(this.div.style.boxSizing).toBe("border-box");
+        var div = this.div.children[0];
+        expect(div.className).toBe(element);
+        expect(div.style.boxSizing).toBe("border-box");
       }
       expect(qml.Component).not.toBe(undefined);
     });

--- a/tests/QMLEngine/bindings.js
+++ b/tests/QMLEngine/bindings.js
@@ -4,8 +4,9 @@ describe("QMLEngine.bindings", function() {
 
   it("NoSrc", function() {
     load("NoSrc", this.div);
-    expect(this.div.offsetWidth).toBe(10);
-    expect(this.div.offsetHeight).toBe(12);
+    var div = this.div.children[0];
+    expect(div.offsetWidth).toBe(10);
+    expect(div.offsetHeight).toBe(12);
   });
 
   it("update immediately", function() {

--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -4,15 +4,17 @@ describe("QMLEngine.imports", function() {
 
   it("Javascript", function() {
     load("Javascript", this.div);
-    expect(this.div.offsetWidth).toBe(20);
-    expect(this.div.offsetHeight).toBe(10);
-    expect(this.div.children[0].style.backgroundColor).toBe("rgb(255, 0, 255)");
+    var div = this.div.children[0];
+    expect(div.offsetWidth).toBe(20);
+    expect(div.offsetHeight).toBe(10);
+    expect(div.children[0].style.backgroundColor).toBe("rgb(255, 0, 255)");
   });
   it("Qmldir", function() {
     load("Qmldir", this.div);
-    expect(this.div.offsetWidth).toBe(50);
-    expect(this.div.offsetHeight).toBe(100);
-    expect(this.div.children[0].style.backgroundColor).toBe("green");
+    var div = this.div.children[0];
+    expect(div.offsetWidth).toBe(50);
+    expect(div.offsetHeight).toBe(100);
+    expect(div.children[0].style.backgroundColor).toBe("green");
     // #0ff and cyan doesn't work, because PhantomJS converts
     // them to rgb( 0,255,255 ).. how to compare colors?..
   });

--- a/tests/QtQuick/Item.js
+++ b/tests/QtQuick/Item.js
@@ -4,14 +4,16 @@ describe("QtQuick.Item", function() {
 
   it("Empty", function() {
     load("Empty", this.div);
-    expect(this.div.innerHTML).toBe("");
-    expect(this.div.style.backgroundColor).toBe("");
+    var div = this.div.children[0];
+    expect(div.innerHTML).toBe("");
+    expect(div.style.backgroundColor).toBe("");
   });
   it("Size", function() {
     load("Size", this.div);
-    expect(this.div.offsetWidth).toBe(200);
-    expect(this.div.offsetHeight).toBe(100);
-    expect(this.div.clientWidth).toBe(200);
-    expect(this.div.clientHeight).toBe(100);
+    var div = this.div.children[0];
+    expect(div.offsetWidth).toBe(200);
+    expect(div.offsetHeight).toBe(100);
+    expect(div.clientWidth).toBe(200);
+    expect(div.clientHeight).toBe(100);
   });
 });

--- a/tests/QtQuick/Rectangle.js
+++ b/tests/QtQuick/Rectangle.js
@@ -4,19 +4,22 @@ describe("QtQuick.Rectangle", function() {
 
   it("White", function() {
     load("White", this.div);
-    expect(this.div.children[0].innerHTML).toBe("");
-    expect(this.div.children[0].style.backgroundColor).toBe("white");
-    expect(this.div.offsetWidth).toBe(200);
-    expect(this.div.offsetHeight).toBe(100);
-    expect(this.div.clientWidth).toBe(200);
-    expect(this.div.clientHeight).toBe(100);
+    var div = this.div.children[0];
+    expect(div.children[0].innerHTML).toBe("");
+    expect(div.children[0].style.backgroundColor).toBe("white");
+    expect(div.offsetWidth).toBe(200);
+    expect(div.offsetHeight).toBe(100);
+    expect(div.clientWidth).toBe(200);
+    expect(div.clientHeight).toBe(100);
   });
   it("Color", function() {
     load("Color", this.div);
-    expect(this.div.children[0].style.backgroundColor).toBe("red");
+    var div = this.div.children[0];
+    expect(div.children[0].style.backgroundColor).toBe("red");
   });
   it("Transparent", function() {
     load("Transparent", this.div);
-    expect(this.div.children[0].style.backgroundColor).toBe("transparent");
+    var div = this.div.children[0];
+    expect(div.children[0].style.backgroundColor).toBe("transparent");
   });
 });


### PR DESCRIPTION
This is a breaking change, and it alters test expectations.

Before this change, all top-level QML elements were created in place of the DOM element passed to `QMLEngine(element)` constructor (let's call it «bounding element») and altered that element significantly, setting its width and height.

This PR only slightly changes the style of bounding element (ensuring `position` and `overflow: hidden`) and places the top-level QML DOM element **inside** the bounding element instead.

That allows to preserve the implicit sizing of the bounding `element` when needed, and QML element sizes are now be recalculated in runtime.

Bounding element size now always sets the top-level QML element `width` and `height` (instead of `implicitWidth` and `implicitHeight`), as it should.

Also the bounding element contents are not replaced now, but preserved.

Commit messages are not yet final and subject to change (I will explain things better and copy description from this PR). I will also squash the two commits here, they are split to make the review easier (tests changes are put into a separate commit for now).

This utilizes `window.getComputedStyle`, which [is available](http://caniuse.com/getComputedStyle) on everything newer than IE8, which we already don't support.

~Also, Shadow DOM v1 support is introduced, which allows us to hide and isolate the implementation so that it doesn't get affected by css styles. It is used only when supported and could be disabled either globally or per QMLEngine.~

_Upd: removed Shadow DOM support from this PR, because it broke implicit `Text` size calculation. I will file Shadow DOM support as a separate PR. Extracted to #368._

Fixes: ~#365,~ #366.
This will also allow to simplify #363.

/cc @akreuzkamp @Plaristote @stephenmdangelo 