### PR TITLE
QMLEngine: add Shadow DOM v1 for isolation

### DIFF
--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -2,6 +2,8 @@
 // This variable points to the currently running engine.
 QmlWeb.engine = null;
 
+QmlWeb.useShadowDom = true;
+
 const geometryProperties = [
   "width", "height", "fill", "x", "y", "left", "right", "top", "bottom"
 ];
@@ -15,6 +17,12 @@ class QMLEngine {
     // Math.floor, causes bugs to timing?
     this.$interval = Math.floor(1000 / this.fps);
     this.dom = element || document.body;
+
+    // Target for the DOM children
+    this.domTarget = this.dom;
+    if (QmlWeb.useShadowDom && this.dom.attachShadow) {
+      this.domTarget = this.dom.attachShadow({ mode: "open" });
+    }
 
     // Cached component trees (post-QmlWeb.convertToEngine)
     this.components = {};
@@ -218,7 +226,7 @@ class QMLEngine {
 
     this.rootObject = component.$createObject(parentComponent);
     if (this.rootObject.dom) {
-      this.dom.appendChild(this.rootObject.dom);
+      this.domTarget.appendChild(this.rootObject.dom);
     }
     component.finalizeImports(this.rootContext());
     this.$initializePropertyBindings();

--- a/src/modules/QtQuick/Text.js
+++ b/src/modules/QtQuick/Text.js
@@ -135,7 +135,14 @@ QmlWeb.registerQmlType({
     // Need to move the child out of it's parent so that it can properly
     // recalculate it's "natural" offsetWidth/offsetHeight
     if (this.$isUsingImplicitWidth) {
-      document.body.appendChild(fc);
+      const engine = QmlWeb.engine;
+      if (engine.dom === document.body && engine.dom !== engine.domTarget) {
+        // Can't use document.body here, as it could have Shadow DOM inside
+        // The root is document.body, though, so it's probably not hidden
+        engine.domTarget.appendChild(fc);
+      } else {
+        document.body.appendChild(fc);
+      }
     }
     const height = fc.offsetHeight;
     const width = fc.offsetWidth;

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,3 +1,7 @@
+// We need to disable Shadow DOM isolation for tests, as we inspect
+// the DOM contents of QML elements through .children
+QmlWeb.useShadowDom = false;
+
 function loadQmlFile(file, div, opts) {
   var engine = new QmlWeb.QMLEngine(div, opts || {});
   engine.loadFile(file);


### PR DESCRIPTION
_Note: only the last commit does the stuff here, this is based on #367. Please see only that single commit that deals with Shadow DOM v1._

Shadow DOM v1 support is introduced, which allows us to hide and isolate the implementation so that it doesn't get affected by css styles.

It is used only when supported and is enabled by default, and could be disabled globally through `QmlWeb.useShadowDom` flag.

I could add the flag as an option to `QMLEngine`, but I don't see a specific usecase for that, so I decided not to overengineer. We could always introduce that flag as on option to `QMLEngine` constructor later, if needed (defaulting to `QmlWeb.useShadowDom`).
    
Fixes: https://github.com/qmlweb/qmlweb/issues/365

/cc @akreuzkamp @Plaristote @stephenmdangelo