### PR TITLE
Loader: fix children context

### DIFF
--- a/src/modules/QtQuick/Loader.js
+++ b/src/modules/QtQuick/Loader.js
@@ -52,7 +52,7 @@ QmlWeb.registerQmlType({
 
     const tree = QmlWeb.engine.loadComponent(fileName);
     const QMLComponent = QmlWeb.getConstructor("QtQml", "2.0", "Component");
-    const meta = { object: tree, context: this, parent: this };
+    const meta = { object: tree, context: this.$context, parent: this };
     const qmlComponent = new QMLComponent(meta);
     qmlComponent.$basePath = QmlWeb.engine.extractBasePath(tree.$file);
     qmlComponent.$imports = tree.$imports;

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -2,9 +2,6 @@ window.failingTests = {
   Render: {
     Async: [
       "NumberAnimationAutorun"
-    ],
-    Simple: [
-      "LoaderScope"
     ]
   },
   QMLEngine: {


### PR DESCRIPTION
Fixes: https://github.com/qmlweb/qmlweb/issues/371

This works, I'm mostly sure that it was intended to be that way. Not 100%, though — I'm not very familiar with the contexts and scopes in QmlWeb.

It would be very nice if someone else could confirm this.

/cc @Plaristote @stephenmdangelo @akreuzkamp 