### PR TITLE
Timer: make parent not read-only for now

### DIFF
--- a/src/modules/QtQml/Timer.js
+++ b/src/modules/QtQml/Timer.js
@@ -5,7 +5,7 @@ QmlWeb.registerQmlType({
   baseClass: "QtObject",
   properties: {
     interval: { type: "int", initialValue: 1000 },
-    parent: { type: "QtObject", readOnly: true },
+    parent: { type: "QtObject" }, // TODO ro
     repeat: "bool",
     running: "bool",
     triggeredOnStart: "bool"


### PR DESCRIPTION
Some parts of QmlWeb set .parent property directly, that was causing a
conflict and an exception was being thrown.

Long-term, we should create a better fix, but this fixes the immediate
problem for now, and properties not being read-only when they should
causes much less damage than unexpected exceptions on valid qml code.

This still need a testcase.