### PR TITLE
Create QtGraphicalEffects:RectangularGlow.js

### DIFF
--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -60,20 +60,20 @@ QmlWeb.registerQmlType({
   $updateBoxShadow() {
 
     function calcBoxShadow(color, glowR, cornerR, spread) {
-      let totle = glowR + cornerR * (1 - spread);
-      let glow = (1 - spread) * totle;
-      let blur_radius = glow * 0.64;
-      let spread_radius = totle - blur_radius;
-      let glow2 = glowR / 5;
-      let blur_radius_2 = glow2 * 0.8;
-      let spread_radius_2 = glow2 - blur_radius_2;
+      const totle = glowR + cornerR * (1 - spread);
+      const glow = (1 - spread) * totle;
+      const blur_radius = glow * 0.64;
+      const spread_radius = totle - blur_radius;
+      const glow2 = glowR / 5;
+      const blur_radius_2 = glow2 * 0.8;
+      const spread_radius_2 = glow2 - blur_radius_2;
       return `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
         `${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`;
     }
 
     function calcGlowCss(color, glowR, cornerR, spread, width, height) {
-      let spread_cornerR = cornerR * (1 - spread);
-      let rest_cornerR = cornerR - spread_cornerR;
+      const spread_cornerR = cornerR * (1 - spread);
+      const rest_cornerR = cornerR - spread_cornerR;
       return {
         boxShadow: calcBoxShadow(color, glowR, cornerR, spread),
         width: `${width - spread_cornerR}px`,

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -1,0 +1,92 @@
+QmlWeb.registerQmlType({
+  module: "QtQuick",
+  name: "RectangularGlow",
+  versions: /.*/,
+  baseClass: "Item",
+  properties: {
+    cached: {
+      type: "bool",
+      initialValue: false
+    },
+    color: {
+      type: "color",
+      initialValue: "white"
+    },
+    cornerRadius: {
+      type: "real",
+      initialValue: 0
+    },
+    // This property defines how many pixels outside the item area are reached by the glow.
+    glowRadius: {
+      type: "real",
+      initialValue: 0
+    },
+    spread: {
+      type: "real",
+      initialValue: 0
+    },
+  }
+}, class {
+  constructor(meta) {
+    QmlWeb.callSuper(this, meta);
+
+    const bg = this.impl = document.createElement("div");
+    bg.style.pointerEvents = "none";
+    bg.style.position = "absolute";
+    bg.style.left = bg.style.right = bg.style.top = bg.style.bottom = "0px";
+    bg.style.border = "none";
+    bg.style.backgroundColor = "black";
+    this.dom.appendChild(bg);
+
+    this.colorChanged.connect(this, this.$onColorChanged);
+    this.glowRadiusChanged.connect(this, this.$updateBoxShadow);
+    this.cornerRadiusChanged.connect(this, this.$updateBoxShadow);
+    this.widthChanged.connect(this, this.$updateBoxShadow);
+    this.heightChanged.connect(this, this.$updateBoxShadow);
+    this.spreadChanged.connect(this, this.$onSpreadChanged);
+  }
+  $onColorChanged(newVal) {
+    this.impl.style.backgroundColor = new QmlWeb.QColor(newVal);
+    this.$updateBoxShadow();
+  }
+  $onSpreadChanged(newVal) {
+    if (newVal > 1) {
+      this.spread = 1
+    } else if (newVal < 0) {
+      this.spread = 0
+    }
+    this.$updateBoxShadow();
+  }
+
+  $updateBoxShadow() {
+
+    function calcBoxShadow(color, glowR, cornerR, spread) {
+      var totle = (glowR + cornerR * (1 - spread));
+      var glow = (1 - spread) * totle;
+      var blur_radius = glow * 0.64;
+      var spread_radius = totle - blur_radius;
+      var glow2 = glowR / 5;
+      var blur_radius_2 = glow2 * 0.8;
+      var spread_radius_2 = glow2 - blur_radius_2;
+      return `${color} 0px 0px ${blur_radius}px ${spread_radius}px,
+            ${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`
+    }
+
+    function calcGlowCss(color, glowR, cornerR, spread, width, height) {
+      var spread_cornerR = cornerR * (1 - spread);
+      var rest_cornerR = cornerR - spread_cornerR;
+      return {
+        boxShadow: calcBoxShadow(color, glowR, cornerR, spread),
+        width: `${width - spread_cornerR}px`,
+        height: `${height - spread_cornerR}px`,
+        top: `${spread_cornerR / 2}px`,
+        left: `${spread_cornerR / 2}px`,
+        filter: `blur(${spread_cornerR / 2}px)`,
+        borderRadius: `${cornerR / 2}px`,
+        transform: `scale(${(width - spread_cornerR / 4) / width},${(height - spread_cornerR / 4) / height})`,
+      }
+    }
+
+    Object.assign(this.impl.style, calcGlowCss(this.color, this.glowRadius, this.cornerRadius, this.spread, this.width, this.height));
+  }
+});

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -1,8 +1,8 @@
 QmlWeb.registerQmlType({
-  module: "QtQuick",
+  module: "QtGraphicalEffects",
   name: "RectangularGlow",
   versions: /.*/,
-  baseClass: "Item",
+  baseClass: "QtQuick.Item",
   properties: {
     cached: {
       type: "bool"

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -4,34 +4,24 @@ QmlWeb.registerQmlType({
   versions: /.*/,
   baseClass: "QtQuick.Item",
   properties: {
-    cached: {
-      type: "bool"
-    },
-    color: {
-      type: "color",
-      initialValue: "white"
-    },
-    cornerRadius: {
-      type: "real"
-    },
-    glowRadius: {
-      type: "real"
-    },
-    spread: {
-      type: "real"
-    },
+    cached: "bool",
+    color: { type: "color", initialValue: "white" },
+    cornerRadius: "real",
+    glowRadius: "real",
+    spread: "real"
   }
 }, class {
   constructor(meta) {
     QmlWeb.callSuper(this, meta);
 
-    const bg = this.impl = document.createElement("div");
-    bg.style.pointerEvents = "none";
-    bg.style.position = "absolute";
-    bg.style.left = bg.style.right = bg.style.top = bg.style.bottom = "0px";
-    bg.style.border = "none";
-    bg.style.backgroundColor = "black";
-    this.dom.appendChild(bg);
+    this.impl = document.createElement("div");
+    const style = this.impl.style;
+    style.pointerEvents = "none";
+    style.position = "absolute";
+    style.left = style.right = style.top = style.bottom = "0px";
+    style.border = "none";
+    style.backgroundColor = "black";
+    this.dom.appendChild(this.impl);
 
     this.colorChanged.connect(this, this.$onColorChanged);
     this.glowRadiusChanged.connect(this, this.$updateBoxShadow);
@@ -41,7 +31,7 @@ QmlWeb.registerQmlType({
     this.spreadChanged.connect(this, this.$onSpreadChanged);
   }
   $onColorChanged(newVal) {
-    this.impl.style.backgroundColor = new QmlWeb.QColor(newVal);
+    this.impl.style.backgroundColor = newVal;
     this.$updateBoxShadow();
   }
   $onSpreadChanged(newVal) {
@@ -53,40 +43,33 @@ QmlWeb.registerQmlType({
     this.$updateBoxShadow();
   }
   $updateBoxShadow() {
-    const {
-      color,
-      glowRadius: glowR,
-      cornerRadius: cornerR,
-      spread,
-      width,
-      height
-    } = this;
-    const currentStyle = this.impl.style;
+    const { color, glowRadius, cornerRadius, spread, width, height } = this;
+    const style = this.impl.style;
 
-    //calcBoxShadow
-    const totle = glowR + cornerR * (1 - spread);
+    // Calculate boxShadow
+    const totle = glowRadius + cornerRadius * (1 - spread);
     const glow = (1 - spread) * totle;
     const blur_radius = glow * 0.64;
     const spread_radius = totle - blur_radius;
-    const glow2 = glowR / 5;
+    const glow2 = glowRadius / 5;
     const blur_radius_2 = glow2 * 0.8;
     const spread_radius_2 = glow2 - blur_radius_2;
 
-    const boxShadow = `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
+    style.boxShadow = `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
       `${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`;
 
-    //calcGlowCss
-    const spread_cornerR = cornerR * (1 - spread);
-    const rest_cornerR = cornerR - spread_cornerR;
+    // Calculate glow css
+    const spread_cornerR = cornerRadius * (1 - spread);
+    const rest_cornerR = cornerRadius - spread_cornerR;
+    const xScale = (width - spread_cornerR / 4) / width;
+    const yScale = (height - spread_cornerR / 4) / height;
 
-    currentStyle.boxShadow = boxShadow;
-    currentStyle.width = `${width - spread_cornerR}px`;
-    currentStyle.height = `${height - spread_cornerR}px`;
-    currentStyle.top = `${spread_cornerR / 2}px`;
-    currentStyle.left = `${spread_cornerR / 2}px`;
-    currentStyle.filter = `blur(${spread_cornerR / 2}px)`;
-    currentStyle.borderRadius = `${rest_cornerR / 2}px`;
-    currentStyle.transform = `scale(${(width - spread_cornerR / 4) / width},` +
-      `${(height - spread_cornerR / 4) / height})`;
+    style.width = `${width - spread_cornerR}px`;
+    style.height = `${height - spread_cornerR}px`;
+    style.top = `${spread_cornerR / 2}px`;
+    style.left = `${spread_cornerR / 2}px`;
+    style.filter = `blur(${spread_cornerR / 2}px)`;
+    style.borderRadius = `${rest_cornerR / 2}px`;
+    style.transform = `scale(${xScale},${yScale})`;
   }
 });

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -5,24 +5,20 @@ QmlWeb.registerQmlType({
   baseClass: "Item",
   properties: {
     cached: {
-      type: "bool",
-      initialValue: false
+      type: "bool"
     },
     color: {
       type: "color",
       initialValue: "white"
     },
     cornerRadius: {
-      type: "real",
-      initialValue: 0
+      type: "real"
     },
     glowRadius: {
-      type: "real",
-      initialValue: 0
+      type: "real"
     },
     spread: {
-      type: "real",
-      initialValue: 0
+      type: "real"
     },
   }
 }, class {
@@ -57,39 +53,40 @@ QmlWeb.registerQmlType({
     this.$updateBoxShadow();
   }
   $updateBoxShadow() {
-    function calcBoxShadow(color, glowR, cornerR, spread) {
-      const totle = glowR + cornerR * (1 - spread);
-      const glow = (1 - spread) * totle;
-      const blur_radius = glow * 0.64;
-      const spread_radius = totle - blur_radius;
-      const glow2 = glowR / 5;
-      const blur_radius_2 = glow2 * 0.8;
-      const spread_radius_2 = glow2 - blur_radius_2;
-      return `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
-        `${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`;
-    }
+    const {
+      color,
+      glowRadius: glowR,
+      cornerRadius: cornerR,
+      spread,
+      width,
+      height
+    } = this;
+    const currentStyle = this.impl.style;
 
-    function calcGlowCss(color, glowR, cornerR, spread, width, height) {
-      const spread_cornerR = cornerR * (1 - spread);
-      const rest_cornerR = cornerR - spread_cornerR;
-      return {
-        boxShadow: calcBoxShadow(color, glowR, cornerR, spread),
-        width: `${width - spread_cornerR}px`,
-        height: `${height - spread_cornerR}px`,
-        top: `${spread_cornerR / 2}px`,
-        left: `${spread_cornerR / 2}px`,
-        filter: `blur(${spread_cornerR / 2}px)`,
-        borderRadius: `${rest_cornerR / 2}px`,
-        transform: `scale(${(width - spread_cornerR / 4) / width},` +
-          `${(height - spread_cornerR / 4) / height})`,
-      };
-    }
+    //calcBoxShadow
+    const totle = glowR + cornerR * (1 - spread);
+    const glow = (1 - spread) * totle;
+    const blur_radius = glow * 0.64;
+    const spread_radius = totle - blur_radius;
+    const glow2 = glowR / 5;
+    const blur_radius_2 = glow2 * 0.8;
+    const spread_radius_2 = glow2 - blur_radius_2;
 
-    Object.assign(this.impl.style, calcGlowCss(
-      this.color,
-      this.glowRadius,
-      this.cornerRadius,
-      this.spread,
-      this.width, this.height));
+    const boxShadow = `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
+      `${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`;
+
+    //calcGlowCss
+    const spread_cornerR = cornerR * (1 - spread);
+    const rest_cornerR = cornerR - spread_cornerR;
+
+    currentStyle.boxShadow = boxShadow;
+    currentStyle.width = `${width - spread_cornerR}px`;
+    currentStyle.height = `${height - spread_cornerR}px`;
+    currentStyle.top = `${spread_cornerR / 2}px`;
+    currentStyle.left = `${spread_cornerR / 2}px`;
+    currentStyle.filter = `blur(${spread_cornerR / 2}px)`;
+    currentStyle.borderRadius = `${rest_cornerR / 2}px`;
+    currentStyle.transform = `scale(${(width - spread_cornerR / 4) / width},` +
+      `${(height - spread_cornerR / 4) / height})`;
   }
 });

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -16,7 +16,6 @@ QmlWeb.registerQmlType({
       type: "real",
       initialValue: 0
     },
-    // This property defines how many pixels outside the item area are reached by the glow.
     glowRadius: {
       type: "real",
       initialValue: 0
@@ -51,9 +50,9 @@ QmlWeb.registerQmlType({
   }
   $onSpreadChanged(newVal) {
     if (newVal > 1) {
-      this.spread = 1
+      this.spread = 1;
     } else if (newVal < 0) {
-      this.spread = 0
+      this.spread = 0;
     }
     this.$updateBoxShadow();
   }
@@ -61,20 +60,20 @@ QmlWeb.registerQmlType({
   $updateBoxShadow() {
 
     function calcBoxShadow(color, glowR, cornerR, spread) {
-      var totle = (glowR + cornerR * (1 - spread));
-      var glow = (1 - spread) * totle;
-      var blur_radius = glow * 0.64;
-      var spread_radius = totle - blur_radius;
-      var glow2 = glowR / 5;
-      var blur_radius_2 = glow2 * 0.8;
-      var spread_radius_2 = glow2 - blur_radius_2;
-      return `${color} 0px 0px ${blur_radius}px ${spread_radius}px,
-            ${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`
+      let totle = glowR + cornerR * (1 - spread);
+      let glow = (1 - spread) * totle;
+      let blur_radius = glow * 0.64;
+      let spread_radius = totle - blur_radius;
+      let glow2 = glowR / 5;
+      let blur_radius_2 = glow2 * 0.8;
+      let spread_radius_2 = glow2 - blur_radius_2;
+      return `${color} 0px 0px ${blur_radius}px ${spread_radius}px,` +
+        `${color} 0px 0px ${blur_radius_2}px ${spread_radius_2}px`;
     }
 
     function calcGlowCss(color, glowR, cornerR, spread, width, height) {
-      var spread_cornerR = cornerR * (1 - spread);
-      var rest_cornerR = cornerR - spread_cornerR;
+      let spread_cornerR = cornerR * (1 - spread);
+      let rest_cornerR = cornerR - spread_cornerR;
       return {
         boxShadow: calcBoxShadow(color, glowR, cornerR, spread),
         width: `${width - spread_cornerR}px`,
@@ -82,11 +81,17 @@ QmlWeb.registerQmlType({
         top: `${spread_cornerR / 2}px`,
         left: `${spread_cornerR / 2}px`,
         filter: `blur(${spread_cornerR / 2}px)`,
-        borderRadius: `${cornerR / 2}px`,
-        transform: `scale(${(width - spread_cornerR / 4) / width},${(height - spread_cornerR / 4) / height})`,
-      }
+        borderRadius: `${rest_cornerR / 2}px`,
+        transform: `scale(${(width - spread_cornerR / 4) / width},` +
+          `${(height - spread_cornerR / 4) / height})`,
+      };
     }
 
-    Object.assign(this.impl.style, calcGlowCss(this.color, this.glowRadius, this.cornerRadius, this.spread, this.width, this.height));
+    Object.assign(this.impl.style, calcGlowCss(
+      this.color,
+      this.glowRadius,
+      this.cornerRadius,
+      this.spread,
+      this.width, this.height));
   }
 });

--- a/src/modules/QtGraphicalEffects/RectangularGlow.js
+++ b/src/modules/QtGraphicalEffects/RectangularGlow.js
@@ -56,9 +56,7 @@ QmlWeb.registerQmlType({
     }
     this.$updateBoxShadow();
   }
-
   $updateBoxShadow() {
-
     function calcBoxShadow(color, glowR, cornerR, spread) {
       const totle = glowR + cornerR * (1 - spread);
       const glow = (1 - spread) * totle;

--- a/tests/Initialize/runner.js
+++ b/tests/Initialize/runner.js
@@ -85,7 +85,8 @@ var modules = {
     ParticleSystem: { dom: true }
   },
   "QtGraphicalEffects 1.0": {
-    FastBlur: { dom: true }
+    FastBlur: { dom: true },
+    RectangularGlow: { dom: true }
   },
   "QtMobility 1.2": {
   },


### PR DESCRIPTION
use css `box-shadow` and `filter:blur` to simulate **Glow** effect.
They are very similar, but not exactly the same.

## REFERENCES:
[qml-qtgraphicaleffects-rectangularglow](http://doc.qt.io/qt-5/qml-qtgraphicaleffects-rectangularglow.html)
[css-box-shadow](https://developer.mozilla.org/zh-CN/docs/Web/CSS/box-shadow)

## Screenshots
| prop | qmlweb | qml |
|:----:|------|------|
|  | Chrome | Qt Creator Design Mode, with auxiliary dotted line |
|cornerRadius: 0; spread: 0; glowRadius: 20; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717080/a967acfa-d449-11e6-8603-a1c2f323c569.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717163/2cebe92e-d44a-11e6-908a-ed68506dd10f.png)|
|cornerRadius: 50; spread: 0; glowRadius: 20; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717188/57d8049c-d44a-11e6-91c1-292151223a17.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717215/8d108864-d44a-11e6-893e-c211385073e4.png)|
|cornerRadius: 25; spread: 0; glowRadius: 10; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717260/e61a4d46-d44a-11e6-81d0-5271ca96bb61.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717252/da6d0600-d44a-11e6-9184-6c5264e4f9d1.png)|
|cornerRadius: 25; spread: 0; glowRadius: 40; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717303/11b5b044-d44b-11e6-9755-c03e49f575b7.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717292/0980c5d0-d44b-11e6-917a-e5514a3c16ed.png)|
|cornerRadius: 25; spread: 0; glowRadius: 20; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717330/3dc51e4a-d44b-11e6-838c-4d41a6d095b0.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717327/36e01b16-d44b-11e6-9400-9e910a2ee910.png)|
|cornerRadius: 25; spread: 1; glowRadius: 20; color: "#ffffff";|![image](https://cloud.githubusercontent.com/assets/2151644/21717358/64409f5e-d44b-11e6-9fa9-d4dcc6b70b93.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717351/592a89a4-d44b-11e6-9e09-4dadc3ec5bbe.png)|
|cornerRadius: 25; spread: 0.5; glowRadius: 20; color: "#55ff55";|![image](https://cloud.githubusercontent.com/assets/2151644/21717471/12f714a6-d44c-11e6-85b9-1a2e926dfc4d.png)|![image](https://cloud.githubusercontent.com/assets/2151644/21717476/20e9dddc-d44c-11e6-8aa3-58904a8f174f.png)|
