### PR TITLE
Add Gaubee to AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Alexander Potashev <aspotashev@gmail.com>
 Stephen D'Angelo <stephen.m.dangelo@gmail.com>
 Heikki Haveri <heikki.haveri@pastillilabs.com>
 Alexander Rössler <mail@roessler.systems>
+Gaubee <GaubeeBangeel@Gmail.com>


### PR DESCRIPTION
/cc @Gaubee, please check if this is the preferred name and email.

I extracted that from the b1157439a41f7aa21ccf5761a8d2ee2d539237a0 commit, but you could choose a different name/email if you wish to.