### PR TITLE
Qt: add Qt.platform.os

### DIFF
--- a/src/modules/QtQml/Qt.js
+++ b/src/modules/QtQml/Qt.js
@@ -130,6 +130,10 @@ const Qt = {
     QmlWeb.importJavascriptInContext(js, QmlWeb.executionContext);
   },
 
+  platform: {
+    os: "qmlweb"
+  },
+
   // Buttons masks
   LeftButton: 1,
   RightButton: 2,


### PR DESCRIPTION
There probably isn't much sense in putting an actual underlying OS there,
as we don't support OS-specific features and don't have OS-specific
behaviour differences. It makes sense to distinguish browser platform
from all the other ones, though.

So it's set to 'qmlweb', as other values could be used by Qt QML.

Refs: http://doc.qt.io/qt-5/qml-qtqml-qt.html#platform-prop