### PR TITLE
QColor: remove comparable colors hack

### DIFF
--- a/src/engine/QMLProperty.js
+++ b/src/engine/QMLProperty.js
@@ -135,10 +135,6 @@ class QMLProperty {
       );
     }
 
-    if (this.val && this.val.$get) {
-      return this.val.$get();
-    }
-
     return this.val;
   }
   // Define setter

--- a/src/qtbase/QColor.js
+++ b/src/qtbase/QColor.js
@@ -189,32 +189,7 @@ class QColor {
     this.$string = this.$cssValue = null;
     this.$changed.execute();
   }
-  $get() {
-    // Returns the same instance for all equivalent colors.
-    // NOTE: the returned value should not be changed using method calls, if
-    // those would be added in the future, the returned value should be wrapped.
-    const id = this.toString();
-    if (!QColor.$colors[id]) {
-      if (QColor.$colorsCount >= QColor.comparableColorsLimit) {
-        // Too many colors created, bail out to avoid memory hit
-        return this;
-      }
-      QColor.$colors[id] = this;
-      QColor.$colorsCount++;
-      if (QColor.$colorsCount === QColor.comparableColorsLimit) {
-        console.warn(
-          "QmlWeb: the number of QColor instances reached the limit set in",
-          "QmlWeb.QColor.comparableColorsLimit. Further created colors would",
-          "not be comparable to avoid memory hit."
-        );
-      }
-    }
-    return QColor.$colors[id];
-  }
 }
-QColor.$colors = {};
-QColor.$colorsCount = 0;
-QColor.comparableColorsLimit = 10000;
 QColor.rgba = (r, g, b, a = 1) => new QColor(r, g, b, a);
 QColor.hsva = (h, s, v, a = 1) => new QColor(...QColor.$hsv(h, s, v), a);
 QColor.hsla = (h, s, l, a = 1) => new QColor(...QColor.$hsl(h, s, l), a);

--- a/tests/Auto/QtQuick/tst_color.qml
+++ b/tests/Auto/QtQuick/tst_color.qml
@@ -7,6 +7,7 @@ TestCase {
   property color bar: "#abcdef"
   property color green: 'green'
   property color alpha: '#11aa33CC'
+  property color tmp
 
   function test_toString() {
     compare(green.toString(), '#008000')
@@ -62,11 +63,25 @@ TestCase {
     verify(!Qt.colorEqual("#aabbcc", "#abe"))
   }
   function tests_compare() {
+    /* in QmlWeb, comparing colors works only with Qt.colorEqual
     verify(foo === bar);
     verify(foo == bar);
+    */
+    verify(Qt.colorEqual(foo, bar));
     verify(foo == "#abcdef");
     verify(foo !== "#abcDEF");
     verify(foo != "#abcDEF");
     verify(foo !== "#abcdef");
+  }
+  function test_rbga_set() {
+    tmp = 'green';
+    verify(Qt.colorEqual(tmp, "#008000"))
+    tmp.r = 0.6;
+    verify(Qt.colorEqual(tmp, "#998000"))
+    tmp.g = 0.4;
+    tmp.b = 0.2;
+    verify(Qt.colorEqual(tmp, "#996633"))
+    tmp.a = 0.4;
+    verify(Qt.colorEqual(tmp, "#66996633"))
   }
 }


### PR DESCRIPTION
When colors were modified using setter properties, that hack caused all
colors that were equal to the current one also being modified.

Breaking ==/=== that have an alternative of using Qt.colorEqual is
better than breaking color property setters.

/cc @Gaubee 