### PR TITLE
build: rename qt.js to qmlweb.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Using one of the methods below, install the qmlweb JavaScript library:
   `tar -xaf v0.2.0.tar.gz`
 * Manually (recommended if you cloned from git) — `npm install && npm run build`
 
-Next, simply add `lib/qt.js` to the list of other JavaScript files in your app's
-HTML file:
+Next, simply add `lib/qmlweb.js` to the list of other JavaScript files in your
+app's HTML file:
 
 ```HTML
-<script type="text/javascript" src="/lib/qt.js"></script>
+<script type="text/javascript" src="/lib/qmlweb.js"></script>
 ```
 
 See the [examples](examples) directory for more details and complete usage
@@ -75,7 +75,7 @@ the page is opened. The loaded QML element will fill the whole page.
 <html>
   <head>
     <title>QML Auto-load Example</title>
-    <script type="text/javascript" src="/lib/qt.js"></script>
+    <script type="text/javascript" src="/lib/qmlweb.js"></script>
   </head>
   <body style="margin: 0" data-qml="qml/main.qml">
   </body>

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "qmlweb",
   "description": "QML port to Javascript",
-  "main": "lib/qt.min.js",
+  "main": "lib/qmlweb.min.js",
   "license": "BSD",
   "keywords": [
     "qml",

--- a/examples/customelement.html
+++ b/examples/customelement.html
@@ -8,7 +8,7 @@
     <!-- Custom elements polyfill. See https://github.com/webcomponents/custom-elements for details.
          Don't use this link in production, install a specific release. -->
     <script src="https://rawgit.com/webcomponents/custom-elements/master/custom-elements.min.js"></script>
-    <script src="../lib/qt.js"></script>
+    <script src="../lib/qmlweb.js"></script>
     <script>
       QmlWeb.registerElement('qml-main', 'qml/main.qml');
     </script>

--- a/examples/embed.html
+++ b/examples/embed.html
@@ -9,7 +9,7 @@
         border: 10px dotted red;
       }
     </style>
-    <script src="../lib/qt.js"></script>
+    <script src="../lib/qmlweb.js"></script>
   </head>
   <body>
     <div id="embed">

--- a/examples/fullpage.html
+++ b/examples/fullpage.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>QML Fullpage Auto-load Example</title>
-    <script src="../lib/qt.js"></script>
+    <script src="../lib/qmlweb.js"></script>
   </head>
   <body style="margin: 0" data-qml="qml/main.qml">
   </body>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = function(config) {
     basePath: "",
     frameworks: ["jasmine"],
     files: [
-      config.coverageEnabled ? "tmp/qt.covered.js" : "lib/qt.js",
+      config.coverageEnabled ? "tmp/qmlweb.covered.js" : "lib/qmlweb.js",
       { pattern: "lib/*.js", included: false },
       { pattern: "lib/*.js.map", included: false },
       { pattern: "tmp/qmlweb.*.js", included: false },

--- a/src/engine/qmlstructure.js
+++ b/src/engine/qmlstructure.js
@@ -268,8 +268,11 @@ function loadParser() {
   console.log("Loading parser...");
   const tags = document.getElementsByTagName("script");
   for (const i in tags) {
-    if (tags[i].src && tags[i].src.indexOf("/qt.") !== -1) {
-      const src = tags[i].src.replace("/qt.", "/qmlweb.parser.");
+    if (tags[i].src && tags[i].src.match(/\/(qt|qmlweb)\./)) {
+      const src = tags[i].src.replace(
+        /\/(qt|qmlweb)\.(es201.\.)?/,
+        "/qmlweb.parser."
+      );
       // TODO: rewrite to async loading
       const xhr = new XMLHttpRequest();
       xhr.open("GET", src, false);

--- a/tests/qmlweb.js
+++ b/tests/qmlweb.js
@@ -9,7 +9,7 @@ function include(file, window) {
 }
 
 require("jsdom").env("", (err, window) => {
-  include("../lib/qt.js", window);
+  include("../lib/qmlweb.js", window);
   include("../lib/qmlweb.parser.js", window);
 
   const document = window.document;


### PR DESCRIPTION
`qt.js` is still build for backwards compatibility for now.

Fixes: https://github.com/qmlweb/qmlweb/issues/380

/cc @qmlweb/collaborators 