### PR TITLE
Added failingTest for qmldir singleton difinition support

### DIFF
--- a/tests/QMLEngine/imports.js
+++ b/tests/QMLEngine/imports.js
@@ -64,6 +64,13 @@ describe("QMLEngine.imports", function() {
     // #0ff and cyan doesn't work, because PhantomJS converts
     // them to rgb( 0,255,255 ).. how to compare colors?..
   });
+  it("Qmldir singleton", function() {
+    load("QmldirSingleton", this.div);
+    var div = this.div.children[0];
+    expect(div.offsetWidth).toBe(10);
+    expect(div.offsetHeight).toBe(20);
+    expect(div.children[0].style.backgroundColor).toBe("rgb(0, 128, 0)");
+  });
   it("can import from sibling directory", function() {
     var qml = load("From/SiblingDir", this.div);
     expect(qml.text).toBe("I'm simple");

--- a/tests/QMLEngine/qml/ImportQmldirSingleton.qml
+++ b/tests/QMLEngine/qml/ImportQmldirSingleton.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.0
+import "singleton"
+
+Rectangle {
+  height: 10
+  width: 20
+  color: Style.customColor
+}

--- a/tests/QMLEngine/qml/singleton/Style.qml
+++ b/tests/QMLEngine/qml/singleton/Style.qml
@@ -1,0 +1,6 @@
+pragma Singleton
+import QtQuick 2.0
+
+QtObject {
+    property color customColor: "green"
+}

--- a/tests/QMLEngine/qml/singleton/qmldir
+++ b/tests/QMLEngine/qml/singleton/qmldir
@@ -1,0 +1,1 @@
+singleton Style 1.0 Style.qml

--- a/tests/failingTests.js
+++ b/tests/failingTests.js
@@ -8,6 +8,9 @@ window.failingTests = {
     basic: [
       "SignalDisconnect"
     ],
+    imports: [
+      "Qmldir singleton"
+    ],
     scope: [
       "object id should override same-named property of base object"
     ]


### PR DESCRIPTION
In accordance to http://doc.qt.io/qt-5/qtqml-modules-qmldir.html import statement can be declared as singleton. 
For now, this syntax is ignored and shows "unmatched" log message:
https://github.com/qmlweb/qmlweb/blob/9504d996a37cb8f50670b100b5cb51a2613edd7d/src/engine/import.js#L143
Added test covers #436