### PR TITLE
FontLoader.js gives back a font object

### DIFF
--- a/src/modules/QtQuick/FontLoader.js
+++ b/src/modules/QtQuick/FontLoader.js
@@ -82,8 +82,8 @@ class QtQuick_FontLoader extends QtQml_QtObject {
             }
           }
         },
-        fontLoaded: fontFamily => {
-          if (this.$lastName === fontName && fontFamily === fontName) {
+        fontLoaded: font => {
+          if (this.$lastName === fontName && font.family === fontName) {
             this.name = fontName;
             this.status = this.FontLoader.Ready;
           }


### PR DESCRIPTION
Tried to use FontLoader with FontLoader@0.0.2.
Found out that the name property wasn't filled and status was 2 ( Loading )
After debugging I found out that the FontLoader@0.0.2 library gives back a font object with the property family instead of a string containing fontFamily.