### PR TITLE
fix loading files from qrc.js

### DIFF
--- a/src/engine/QMLEngine.js
+++ b/src/engine/QMLEngine.js
@@ -643,21 +643,31 @@ class QMLEngine {
 
   // This parses the full URL into scheme, authority and path
   $parseURI(uri) {
-    const match = uri.match(/^([^/]*?:\/\/)(.*?)(\/.*)$/);
-    if (match) {
-      return {
-        scheme: match[1],
-        authority: match[2],
-        path: match[3]
-      };
+    if (!uri.startsWith("qrc:/")) {
+      const match = uri.match(/^([^/]*?:\/\/)(.*?)(\/.*)$/);
+      if (match) {
+        return {
+          scheme: match[1],
+          authority: match[2],
+          path: match[3]
+        };
+      }
+    } else {
+      const match = uri.match(/^([^/]*?:\/\/?)(.*?)$/);
+      if (match) {
+        return {
+          scheme: "qrc://",
+          authority: "",
+          path: match[2]
+        };
+      }
     }
     return undefined;
   }
 
   // Return a path to load the file
   $resolvePath(file, basePath = this.$basePath) {
-    // probably, replace :// with :/ ?
-    if (!file || file.indexOf("://") !== -1) {
+    if (!file || file.indexOf(":/") !== -1) {
       return file;
     }
 

--- a/tests/QMLEngine/qrc.js
+++ b/tests/QMLEngine/qrc.js
@@ -7,7 +7,7 @@ describe("QMLEngine.qrc", function() {
 
   /* Put some stuff into QmlWeb.qrc, this is what gulp-qmlweb does */
   var qrc_files = [
-    ["/Basic.qml",
+    ["Basic.qml",
       "import QtQuick 2.0\n Item { property int value: 42 }"
     ],
     ["/SomeDir/SomeFile.qml",
@@ -72,7 +72,7 @@ describe("QMLEngine.qrc", function() {
   }
 
   it("basic", function() {
-    var qml = loadQmlFile("qrc:///Basic.qml", this.div);
+    var qml = loadQmlFile("qrc:/Basic.qml", this.div);
     expect(qml.value).toBe(42);
   });
 


### PR DESCRIPTION
Loading components from qrc.js with the `qrc:/` scheme currently doesn't work, making it impossible to use the pre-parsing from `gulp-qmlweb` in it's default state.

This patch fixes the case in which filepaths aren't starting with a slash. I've modified the basic qrc import test to use such a path ("Basic.qml" instead of "/Basic.qml"), and to have it imported by using "qrc:/Basic.qml" instead of "qrc:///Basic.qml" - while both forms are valid QML, the first one seems more common, and only the second one currently works in QmlWeb.

With this patch, `qrc:/` and `qrc://` will both work as scheme for a filepath that doesn't start with a slash (which should be the default behavior for the qrc.js file).
The current behavior described in the tests (using `qrc:///` instead of `qrc:/`, and having all paths start with a slash) still works.

As you wrote the tests for this, maybe you should PR this patch, @stephenmdangelo ?