### PR TITLE
Fix the expression of <p> in HTML

### DIFF
--- a/src/modules/QtQuick/Text.js
+++ b/src/modules/QtQuick/Text.js
@@ -71,6 +71,13 @@ class QtQuick_Text extends QtQuick_Item {
     } else {
       // TODO: sanitize StyledText/RichText
       this.impl.innerHTML = text;
+      const nodes = this.impl.children;
+      for (let i = 0; i < nodes.length; i++) {
+        if (nodes[i].nodeName.toLowerCase() === "p") {
+          nodes[i].style.marginBlockStart = "0em";
+          nodes[i].style.marginBlockEnd = "0.5em";
+        }
+      }
     }
     this.$updateImplicit();
   }


### PR DESCRIPTION
With the rendering of QML the `<p>` element in Rich text does not emit a big white space.
Because there is no 'global CSS' yet in this project I have applied it as Javascript.